### PR TITLE
Pick only exact matched locale for polyfill

### DIFF
--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -129,7 +129,7 @@ module.exports = {
 
       if (this.projectLocales.length) {
         localeFunnel.include = this.projectLocales.map(function(locale) {
-          return new RegExp(locale, 'i');
+          return new RegExp('^' + locale + '.js$', 'i');
         });
       }
 


### PR DESCRIPTION
This fixes #315.

I'll be able to run more test on Monday, but it should be ok.
Is there any other usage I'm not aware of that could be broken by this approach?