### PR TITLE
Fixes options locale bleeding out into the options hash passed into `service.t`

### DIFF
--- a/packages/ember-intl/addon/formatters/-base.js
+++ b/packages/ember-intl/addon/formatters/-base.js
@@ -62,9 +62,9 @@ const FormatBase = EmberObject.extend({
   * @return {Object} Format options hash
   * @private
   */
-  _format(value, formatterOptions = {}, formatOptions = {}) {
+  _format(value, formatterOptions = {}, formatOptions = {}, ctx = {}) {
     const formatter = get(this, 'formatter');
-    const { locale } = formatterOptions;
+    const { locale } = ctx;
 
     if (!locale) {
       throw new Error(

--- a/packages/ember-intl/addon/formatters/format-date.js
+++ b/packages/ember-intl/addon/formatters/format-date.js
@@ -23,13 +23,13 @@ const FormatDate = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options) {
+  format(value, options, ctx={}) {
     const dateTime = new Date(value);
     assertIsDate(dateTime, 'A date or timestamp must be provided to format-date');
 
     const formatOptions = this.filterSupporedOptions(options);
 
-    return this._format(dateTime, formatOptions);
+    return this._format(dateTime, formatOptions, null, ctx);
   }
 });
 

--- a/packages/ember-intl/addon/formatters/format-message.js
+++ b/packages/ember-intl/addon/formatters/format-message.js
@@ -18,7 +18,8 @@ const FormatMessage = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options = {}, formats = {}) {
+  format(value, options = {}, ctx = {}) {
+    const { formats } = ctx;
     const { locale } = options;
     const formatter = get(this, 'formatter');
 

--- a/packages/ember-intl/addon/formatters/format-message.js
+++ b/packages/ember-intl/addon/formatters/format-message.js
@@ -19,8 +19,7 @@ const FormatMessage = Formatter.extend({
   }).readOnly(),
 
   format(value, options = {}, ctx = {}) {
-    const { formats } = ctx;
-    const { locale } = options;
+    const { formats, locale } = ctx;
     const formatter = get(this, 'formatter');
 
     return formatter(value, locale, formats).format(options);

--- a/packages/ember-intl/addon/formatters/format-number.js
+++ b/packages/ember-intl/addon/formatters/format-number.js
@@ -19,8 +19,8 @@ const FormatNumber = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options) {
-    return this._format(value, this.filterSupporedOptions(options));
+  format(value, options, ctx = {}) {
+    return this._format(value, this.filterSupporedOptions(options), null, ctx);
   }
 });
 

--- a/packages/ember-intl/addon/formatters/format-relative.js
+++ b/packages/ember-intl/addon/formatters/format-relative.js
@@ -24,14 +24,14 @@ const FormatRelative = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options = {}) {
+  format(value, options = {}, ctx = {}) {
     const dateValue = new Date(value);
 
     assertIsDate(dateValue, 'A date or timestamp must be provided to format-relative');
 
     return this._format(dateValue, this.filterSupporedOptions(options), {
       now: options.now
-    });
+    }, ctx);
   }
 });
 

--- a/packages/ember-intl/addon/helpers/-format-base.js
+++ b/packages/ember-intl/addon/helpers/-format-base.js
@@ -45,10 +45,14 @@ function helperFactory(formatType, helperOptions = {}) {
       }
 
       const intl = get(this, 'intl');
-      let locale = get(intl, '_locale');
+      let locale = hash.locale;
 
-      if (Array.isArray(locale)) {
-        locale = locale[0];
+      if (!locale) {
+        locale = get(intl, '_locale');
+
+        if (Array.isArray(locale)) {
+          locale = locale[0];
+        }
       }
 
       let format = {};
@@ -59,9 +63,10 @@ function helperFactory(formatType, helperOptions = {}) {
 
       return get(this, 'formatter').format(
         value,
-        assign({ locale }, format, hash),
+        assign(assign({}, format), hash),
         {
-          formats: get(intl, 'formats')
+          formats: get(intl, 'formats'),
+          locale: locale
         }
       );
     },

--- a/packages/ember-intl/addon/helpers/-format-base.js
+++ b/packages/ember-intl/addon/helpers/-format-base.js
@@ -61,7 +61,9 @@ function helperFactory(formatType, helperOptions = {}) {
       return get(this, 'formatter').format(
         value,
         extend({ locale }, format, hash),
-        get(intl, 'formats')
+        {
+          formats: get(intl, 'formats')
+        }
       );
     },
 

--- a/packages/ember-intl/addon/helpers/-format-base.js
+++ b/packages/ember-intl/addon/helpers/-format-base.js
@@ -6,9 +6,8 @@
 import Ember from 'ember';
 import getOwner from 'ember-getowner-polyfill';
 
-import extend from '../utils/extend';
-
 const { Helper, inject, get, computed, isEmpty, getWithDefault } = Ember;
+const assign = Ember.assign || Ember.merge;
 
 function helperFactory(formatType, helperOptions = {}) {
   return Helper.extend({
@@ -60,7 +59,7 @@ function helperFactory(formatType, helperOptions = {}) {
 
       return get(this, 'formatter').format(
         value,
-        extend({ locale }, format, hash),
+        assign({ locale }, format, hash),
         {
           formats: get(intl, 'formats')
         }

--- a/packages/ember-intl/addon/services/intl.js
+++ b/packages/ember-intl/addon/services/intl.js
@@ -25,15 +25,15 @@ function formatterProxy(formatType) {
       options = assign(this.getFormat(formatType, options.format), options);
     }
 
-    if (!options.locale) {
-      options.locale = get(this, '_locale');
-    }
 
     if (!formats) {
       formats = get(this, 'formats');
     }
 
-    return formatter.format(value, options, { formats });
+    return formatter.format(value, options, {
+      formats: formats,
+      locale: options.locale || get(this, '_locale')
+    });
   };
 }
 

--- a/packages/ember-intl/addon/services/intl.js
+++ b/packages/ember-intl/addon/services/intl.js
@@ -33,7 +33,7 @@ function formatterProxy(formatType) {
       formats = get(this, 'formats');
     }
 
-    return formatter.format(value, options, formats);
+    return formatter.format(value, options, { formats });
   };
 }
 

--- a/packages/ember-intl/addon/services/intl.js
+++ b/packages/ember-intl/addon/services/intl.js
@@ -10,11 +10,11 @@ import getOwner from 'ember-getowner-polyfill';
 import IntlMessageFormat from 'intl-messageformat';
 import IntlRelativeFormat from 'intl-relativeformat';
 
-import extend from '../utils/extend';
 import isArrayEqual from '../utils/is-equal';
 
 const { assert, computed, makeArray, get, set, RSVP, Service, Evented, Logger:logger } = Ember;
 const TRANSLATION_PATH_CAPTURE = /\/translations\/(.+)$/;
+const assign = Ember.assign || Ember.merge;
 
 function formatterProxy(formatType) {
   return function (value, options = {}, formats = null) {
@@ -22,7 +22,7 @@ function formatterProxy(formatType) {
     const formatter = owner.lookup(`ember-intl@formatter:format-${formatType}`);
 
     if (typeof options.format === 'string') {
-      options = extend(this.getFormat(formatType, options.format), options);
+      options = assign(this.getFormat(formatType, options.format), options);
     }
 
     if (!options.locale) {

--- a/packages/ember-intl/addon/utils/extend.js
+++ b/packages/ember-intl/addon/utils/extend.js
@@ -1,8 +1,0 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
-import { extend } from 'intl-messageformat/utils';
-
-export default extend;

--- a/packages/ember-intl/tests/unit/services/intl-test.js
+++ b/packages/ember-intl/tests/unit/services/intl-test.js
@@ -3,6 +3,7 @@ import { moduleFor, test } from 'ember-qunit';
 let service;
 
 moduleFor('service:intl', 'Unit | Service | intl', {
+  integration: true,
   setup() {
     service = this.subject();
   }
@@ -21,4 +22,11 @@ test('triggers notifyPropertyChange only when locale changes', function(assert) 
   assert.equal(count, 2);
   assert.equal(service.get('locale'), 'fr');
   service.removeObserver('locale', service, handler);
+});
+
+test('it does not mutate t options hash', function(assert) {
+  service.setLocale('en');
+  let obj = { bar: 'bar' };
+  service.t('foo', obj);
+  assert.ok(typeof obj.locale === 'undefined');
 });


### PR DESCRIPTION
Fixes options locale bleeding out into userland by mutating the options hash passed into `service.t`

See test to see the issue and the fix.