### PR TITLE
Add `isLocalizationFramework` flag.

### DIFF
--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -26,6 +26,7 @@ var TranslationReducer = require('./lib/broccoli/translation-reducer');
 module.exports = {
   name: 'ember-intl',
   opts: null,
+  isLocalizationFramework: true,
 
   included: function(app) {
     this._super.included.apply(this, arguments);


### PR DESCRIPTION
This flag can be found/identified by other addons to provide a better experience.

For example, ember-cli-template-lint would like to provide a warning when templates use "bare strings" (non-translated strings) for projects that are using a localization framework.

When a localization framework is present, and the `bare-strings` rule is not listed in the `.template-lintrc.js` file, a warning will be issued saying:

```
The `bare-strings` rule must be configured when using a localization framework (`ember-intl`). To prevent this warning, add the following to your `.template-lintrc.js`:

  rules: {
    'bare-strings\': true
  }
```

When `ember install ember-cli-template-lint` is ran for the first time in a project that is already using a localization framework, the proper `.template-lintrc.js` file will be generated (so no additional user interaction is needed).

This was implemented in ember-cli-template-lint in https://github.com/rwjblue/ember-cli-template-lint/pull/94 and released in https://github.com/rwjblue/ember-cli-template-lint/releases/tag/v0.4.4.