### PR TITLE
Fix #359 Safari's Can't find variable: Intl error on startup

### DIFF
--- a/packages/ember-intl/app/instance-initializers/ember-intl.js
+++ b/packages/ember-intl/app/instance-initializers/ember-intl.js
@@ -26,7 +26,7 @@ export function instanceInitializer(instance) {
     service = instance.container.lookup('service:intl');
   }
 
-  if (!Intl) {
+  if (typeof Intl === 'undefined') {
     warn('[ember-intl] Intl API is unavailable in this environment.\nSee: ${links.polyfill}', false, {
       id: 'ember-intl-undefined-intljs'
     });


### PR DESCRIPTION
Fixes Issue #359 