### PR TITLE
Format-block component

### DIFF
--- a/packages/ember-intl/addon/components/format-block.js
+++ b/packages/ember-intl/addon/components/format-block.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+import links from '../utils/links';
+
+const { inject } = Ember;
+
+export default Ember.Component.extend({
+  tagName: 'span',
+
+  intl: inject.service(),
+
+  init: Ember.on('init', function() {
+    this._super(...arguments);
+
+    let key = this.get('t');
+    let locale = this.get('locale') || this.get('intl._locale');
+
+    if (!key) {
+      throw new Error(
+        `No translation specified.`
+      );
+    }
+
+    if (!locale) {
+      throw new Error(
+        `No locale specified.  This is typically done application-wide within routes/application.js. Documentation: ${links.unsetLocale}`
+      );
+    }
+
+    let str = this.get('intl').findTranslationByKey(key, locale);
+    this.set('segments', str.split('{yield}'));
+    console.log(this.get('segments'));
+  })
+});

--- a/packages/ember-intl/addon/components/format-block.js
+++ b/packages/ember-intl/addon/components/format-block.js
@@ -28,6 +28,5 @@ export default Ember.Component.extend({
 
     let str = this.get('intl').findTranslationByKey(key, locale);
     this.set('segments', str.split('{yield}'));
-    console.log(this.get('segments'));
   })
 });

--- a/packages/ember-intl/app/components/format-block.js
+++ b/packages/ember-intl/app/components/format-block.js
@@ -1,0 +1,2 @@
+import formatBlock from 'ember-intl/components/format-block';
+export default formatBlock;

--- a/packages/ember-intl/app/templates/components/format-block.hbs
+++ b/packages/ember-intl/app/templates/components/format-block.hbs
@@ -1,0 +1,1 @@
+{{segments.[0]}}{{yield}}{{segments.[1]}}

--- a/packages/ember-intl/tests/dummy/app/controllers/index.js
+++ b/packages/ember-intl/tests/dummy/app/controllers/index.js
@@ -18,6 +18,8 @@ export default Controller.extend({
     photos: '{name} took {numPhotos, plural,\n  =0 {no photos}\n  =1 {one photo}\n  other {# photos}\n} on {takenDate, date, long}.\n'
   },
 
+  people: ['Huey', 'Dewey', 'Louie'],
+
   cp: computed({
     get() {
       return 'product.info';

--- a/packages/ember-intl/tests/dummy/app/helpers/join.js
+++ b/packages/ember-intl/tests/dummy/app/helpers/join.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function listLimiter([list, delimiter]) {
+  return list.join(delimiter);
+}
+
+export default Ember.Helper.helper(listLimiter);

--- a/packages/ember-intl/tests/dummy/app/templates/index.hbs
+++ b/packages/ember-intl/tests/dummy/app/templates/index.hbs
@@ -59,3 +59,10 @@
 </div>
 
 {{code-snippet name='format-html-message.hbs'}}
+
+<h3>Format Block</h3>
+<div>
+  {{#format-block t='product.block'}}
+    {{join people ', '}}
+  {{/format-block}}
+</div>

--- a/packages/ember-intl/tests/dummy/translations/en-us.yaml
+++ b/packages/ember-intl/tests/dummy/translations/en-us.yaml
@@ -3,3 +3,4 @@ product:
   title: 'Hello world!'
   html:
     info: '<strong>{product}</strong> will cost <em>{price, number, USD}</em> if ordered by {deadline, date, time}'
+  block: 'Hi {yield} how are you?'

--- a/packages/ember-intl/tests/unit/helpers/format-block-test.js
+++ b/packages/ember-intl/tests/unit/helpers/format-block-test.js
@@ -1,0 +1,60 @@
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+import Translation from 'ember-intl/models/translation';
+
+const locale = 'en-us';
+let service, registry;
+
+moduleForComponent('format-block', {
+  integration: true,
+  beforeEach() {
+    registry = this.registry || this.container;
+    service = this.container.lookup('service:intl');
+
+    registry.injection('formatter', 'intl', 'service:intl');
+
+    registry.register('ember-intl@translation:en-us', Translation.extend({
+      withoutYield: 'Hello',
+      start: '{yield} with love',
+      middle: 'from {yield} to you',
+      end: 'hello {yield}'
+    }));
+
+    service.setLocale(locale);
+  }
+});
+
+test('should throw error if no key', function(assert) {
+  assert.expect(1);
+  assert.throws(() => {
+    this.render(hbs`{{#format-block ''}}{{/format-block}}`);
+  }, new Error('No translation specified.'));
+});
+
+test('should render with no yield', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{#format-block t='withoutYield'}}{{/format-block}}`);
+
+  assert.equal(this.$().text().trim(), 'Hello');
+});
+
+test('should render with yield in the beginning', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{#format-block t='start'}}from ember{{/format-block}}`);
+
+  assert.equal(this.$().text().trim(), `from ember with love`);
+});
+
+test('should render with yield in the middle', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{#format-block t='middle'}}Santa{{/format-block}}`);
+
+  assert.equal(this.$().text().trim(), `from Santa to you`);
+});
+
+test('should render with yield in the end', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{#format-block t='end'}}Santa{{/format-block}}`);
+
+  assert.equal(this.$().text().trim(), `hello Santa`);
+});


### PR DESCRIPTION
**What have changed**
- Added a component `format-block`. Takes `t` and `locale` as params.
  - `t` is required
  - `locale` is optional

**Why**
- Enabled us to build more complex translations, and use helpers and components in our translations.

This is literally my first time working with add-ons in Ember, so I apologies if this is not the way to do it. Let me know what your thoughts are.
