### PR TITLE
Allow for formatters to be looked up against the app namespace

### DIFF
--- a/packages/ember-intl/addon/formatters/base.js
+++ b/packages/ember-intl/addon/formatters/base.js
@@ -4,8 +4,9 @@
  */
 
 import Ember from 'ember';
-import arrayToHash from '../utils/array-to-hash';
+
 import links from '../utils/links';
+import arrayToHash from '../utils/array-to-hash';
 
 const {
   get,
@@ -38,6 +39,7 @@ const FormatBase = EmberObject.extend({
 
     for (let key in input) {
       camelizedKey = camelize(key);
+
       if (this.options[camelizedKey]) {
         foundMatch = true;
         out[camelizedKey] = input[key];

--- a/packages/ember-intl/addon/formatters/format-date.js
+++ b/packages/ember-intl/addon/formatters/format-date.js
@@ -6,7 +6,7 @@
 import Ember from 'ember';
 import createFormatCache from 'intl-format-cache';
 
-import Formatter from './-base';
+import Formatter from './base';
 
 const { assert, computed } = Ember;
 
@@ -23,7 +23,7 @@ const FormatDate = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options, ctx={}) {
+  format(value, options, ctx = {}) {
     const dateTime = new Date(value);
     assertIsDate(dateTime, 'A date or timestamp must be provided to format-date');
 

--- a/packages/ember-intl/addon/formatters/format-message.js
+++ b/packages/ember-intl/addon/formatters/format-message.js
@@ -7,7 +7,7 @@ import Ember from 'ember';
 import createFormatCache from 'intl-format-cache';
 import IntlMessageFormat from 'intl-messageformat';
 
-import Formatter from './-base';
+import Formatter from './base';
 
 const { get, computed } = Ember;
 

--- a/packages/ember-intl/addon/formatters/format-number.js
+++ b/packages/ember-intl/addon/formatters/format-number.js
@@ -6,7 +6,7 @@
 import Ember from 'ember';
 import createFormatCache from 'intl-format-cache';
 
-import Formatter from './-base';
+import Formatter from './base';
 
 const { computed } = Ember;
 

--- a/packages/ember-intl/addon/formatters/format-relative.js
+++ b/packages/ember-intl/addon/formatters/format-relative.js
@@ -7,7 +7,7 @@ import Ember from 'ember';
 import IntlRelativeFormat from 'intl-relativeformat';
 import createFormatCache from 'intl-format-cache';
 
-import Formatter from './-base';
+import Formatter from './base';
 
 const { assert, computed } = Ember;
 

--- a/packages/ember-intl/addon/helpers/-format-base.js
+++ b/packages/ember-intl/addon/helpers/-format-base.js
@@ -16,7 +16,15 @@ function helperFactory(formatType, helperOptions = {}) {
 
     formatter: computed('formatType', {
       get() {
-        return getOwner(this).lookup(`ember-intl@formatter:format-${formatType}`);
+        const owner = getOwner(this);
+        const lookupName = `formatter:format-${formatType}`;
+
+        // allow for the application to implement custom formatters
+        if (owner.hasRegistration(lookupName)) {
+          return owner.looukp(lookupName);
+        }
+
+        return owner.lookup(`ember-intl@${lookupName}`);
       }
     }).readOnly(),
 


### PR DESCRIPTION
Small change to begin #350, next PR will involve ensuring ember-intl@formatters/base can be public