### PR TITLE
Rename format method to compute

### DIFF
--- a/packages/ember-intl/addon/formatters/-formatter.js
+++ b/packages/ember-intl/addon/formatters/-formatter.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import Ember from 'ember';
+
+import links from '../utils/links';
+import FormatterBase from './base';
+import arrayToHash from '../utils/array-to-hash';
+
+const {
+  computed,
+  get,
+  String:emberString
+} = Ember;
+
+const { camelize } = emberString;
+
+const Formatter = FormatterBase.extend({
+  init(...args) {
+    this._super(...args);
+
+    this.options = arrayToHash(this.constructor.supportedOptions);
+  },
+
+  /**
+  * Filters out all of the whitelisted formatter options
+  *
+  * @method filterSupporedOptions
+  * @param {Object} Options object
+  * @return {Object} Options object containing just whitelisted options
+  * @private
+  */
+  filterSupporedOptions(input = {}) {
+    const out = {};
+
+    let foundMatch = false;
+    let camelizedKey;
+
+    for (let key in input) {
+      camelizedKey = camelize(key);
+
+      if (this.options[camelizedKey]) {
+        foundMatch = true;
+        out[camelizedKey] = input[key];
+      }
+    }
+
+    if (foundMatch) {
+      return out;
+    }
+  },
+
+  formatter: computed({
+    get() {
+      throw new Error('`formatter` was not implemented and is required for formatters');
+    }
+  }),
+
+  /**
+  * Invokes the Intl formatter methods
+  *
+  * @method _format
+  * @param {value} Raw input value that needs formatting
+  * @return {Object} Formatter options hash
+  * @return {Object} Format options hash
+  * @private
+  */
+  _format(value, formatterOptions = {}, formatOptions = {}, ctx = {}) {
+    const formatter = get(this, 'formatter');
+    const { locale } = ctx;
+
+    if (!locale) {
+      throw new Error(
+        `No locale specified.  This is typically done application-wide within routes/application.js. Documentation: ${links.unsetLocale}`
+      );
+    }
+
+    return formatter(locale, formatterOptions).format(value, formatOptions);
+  }
+});
+
+Formatter.reopenClass({
+  supportedOptions: ['locale'],
+  concatenatedProperties: ['supportedOptions']
+});
+
+export default Formatter;

--- a/packages/ember-intl/addon/formatters/base.js
+++ b/packages/ember-intl/addon/formatters/base.js
@@ -5,82 +5,10 @@
 
 import Ember from 'ember';
 
-import links from '../utils/links';
-import arrayToHash from '../utils/array-to-hash';
-
-const {
-  get,
-  String:emberString,
-  Object:EmberObject
-} = Ember;
-
-const { camelize } = emberString;
-
-const FormatBase = EmberObject.extend({
-  init(...args) {
-    this._super(...args);
-
-    this.options = arrayToHash(this.constructor.supportedOptions);
-  },
-
-  /**
-  * Filters out all of the whitelisted formatter options
-  *
-  * @method filterSupporedOptions
-  * @param {Object} Options object
-  * @return {Object} Options object containing just whitelisted options
-  * @private
-  */
-  filterSupporedOptions(input = {}) {
-    const out = {};
-
-    let foundMatch = false;
-    let camelizedKey;
-
-    for (let key in input) {
-      camelizedKey = camelize(key);
-
-      if (this.options[camelizedKey]) {
-        foundMatch = true;
-        out[camelizedKey] = input[key];
-      }
-    }
-
-    if (foundMatch) {
-      return out;
-    }
-  },
-
-  format() {
-    throw new Error('not implemented');
-  },
-
-  /**
-  * Invokes the Intl formatter methods
-  *
-  * @method _format
-  * @param {value} Raw input value that needs formatting
-  * @return {Object} Formatter options hash
-  * @return {Object} Format options hash
-  * @private
-  */
-  _format(value, formatterOptions = {}, formatOptions = {}, ctx = {}) {
-    const formatter = get(this, 'formatter');
-    const { locale } = ctx;
-
-    if (!locale) {
-      throw new Error(
-        `No locale specified.  This is typically done application-wide within routes/application.js. Documentation: ${links.unsetLocale}`
-      );
-    }
-
-    return formatter(locale, formatterOptions).format(value, formatOptions);
+const FormatterBase = Ember.Object.extend({
+  compute(/* value, options, ctx = {} */) {
+    throw new Error('`compute` was not implemented and is required for formatters');
   }
 });
 
-FormatBase.reopenClass({
-  supportedOptions: ['locale', 'format'],
-  concatenatedProperties: ['supportedOptions']
-});
-
-export default FormatBase;
+export default FormatterBase;

--- a/packages/ember-intl/addon/formatters/format-date.js
+++ b/packages/ember-intl/addon/formatters/format-date.js
@@ -6,7 +6,7 @@
 import Ember from 'ember';
 import createFormatCache from 'intl-format-cache';
 
-import Formatter from './base';
+import Formatter from './-formatter';
 
 const { assert, computed } = Ember;
 
@@ -23,7 +23,7 @@ const FormatDate = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options, ctx = {}) {
+  compute(value, options, ctx = {}) {
     const dateTime = new Date(value);
     assertIsDate(dateTime, 'A date or timestamp must be provided to format-date');
 
@@ -37,7 +37,7 @@ FormatDate.reopenClass({
   supportedOptions: [
     'localeMatcher', 'timeZone', 'hour12', 'formatMatcher', 'weekday',
     'era', 'year', 'month', 'day', 'hour', 'minute', 'second',
-    'timeZoneName'
+    'timeZoneName', 'format'
   ]
 });
 

--- a/packages/ember-intl/addon/formatters/format-html-message.js
+++ b/packages/ember-intl/addon/formatters/format-html-message.js
@@ -23,7 +23,7 @@ const FormatHtmlMessage = FormatterMessage.extend({
     }, {});
   },
 
-  format(value, formatOptions = {}) {
+  compute(value, formatOptions = {}) {
     const options = this.escapeProps(formatOptions);
     const superResult = this._super(value, options, formatOptions.locale);
 

--- a/packages/ember-intl/addon/formatters/format-message.js
+++ b/packages/ember-intl/addon/formatters/format-message.js
@@ -7,7 +7,7 @@ import Ember from 'ember';
 import createFormatCache from 'intl-format-cache';
 import IntlMessageFormat from 'intl-messageformat';
 
-import Formatter from './base';
+import Formatter from './-formatter';
 
 const { get, computed } = Ember;
 
@@ -18,12 +18,16 @@ const FormatMessage = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options = {}, ctx = {}) {
+  compute(value, options = {}, ctx = {}) {
     const { formats, locale } = ctx;
     const formatter = get(this, 'formatter');
 
     return formatter(value, locale, formats).format(options);
   }
+});
+
+FormatMessage.reopenClass({
+  supportedOptions: ['format']
 });
 
 export default FormatMessage;

--- a/packages/ember-intl/addon/formatters/format-number.js
+++ b/packages/ember-intl/addon/formatters/format-number.js
@@ -6,7 +6,7 @@
 import Ember from 'ember';
 import createFormatCache from 'intl-format-cache';
 
-import Formatter from './base';
+import Formatter from './-formatter';
 
 const { computed } = Ember;
 
@@ -19,7 +19,7 @@ const FormatNumber = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options, ctx = {}) {
+  compute(value, options, ctx = {}) {
     return this._format(value, this.filterSupporedOptions(options), null, ctx);
   }
 });
@@ -29,7 +29,7 @@ FormatNumber.reopenClass({
     'localeMatcher', 'style', 'currency', 'currencyDisplay',
     'useGrouping', 'minimumIntegerDigits', 'minimumFractionDigits',
     'maximumFractionDigits', 'minimumSignificantDigits',
-    'maximumSignificantDigits'
+    'maximumSignificantDigits', 'format'
   ]
 });
 

--- a/packages/ember-intl/addon/formatters/format-relative.js
+++ b/packages/ember-intl/addon/formatters/format-relative.js
@@ -7,7 +7,7 @@ import Ember from 'ember';
 import IntlRelativeFormat from 'intl-relativeformat';
 import createFormatCache from 'intl-format-cache';
 
-import Formatter from './base';
+import Formatter from './-formatter';
 
 const { assert, computed } = Ember;
 
@@ -24,7 +24,7 @@ const FormatRelative = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options = {}, ctx = {}) {
+  compute(value, options = {}, ctx = {}) {
     const dateValue = new Date(value);
 
     assertIsDate(dateValue, 'A date or timestamp must be provided to format-relative');
@@ -36,7 +36,7 @@ const FormatRelative = Formatter.extend({
 });
 
 FormatRelative.reopenClass({
-  supportedOptions: ['style', 'units']
+  supportedOptions: ['style', 'units', 'format']
 });
 
 export default FormatRelative;

--- a/packages/ember-intl/addon/helpers/-format-base.js
+++ b/packages/ember-intl/addon/helpers/-format-base.js
@@ -4,7 +4,6 @@
  */
 
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 const { Helper, inject, get, computed, isEmpty, getWithDefault } = Ember;
 const assign = Ember.assign || Ember.merge;
@@ -16,15 +15,9 @@ function helperFactory(formatType, helperOptions = {}) {
 
     formatter: computed('formatType', {
       get() {
-        const owner = getOwner(this);
-        const lookupName = `formatter:format-${formatType}`;
+        const intl = get(this, 'intl');
 
-        // allow for the application to implement custom formatters
-        if (owner.hasRegistration(lookupName)) {
-          return owner.looukp(lookupName);
-        }
-
-        return owner.lookup(`ember-intl@${lookupName}`);
+        return intl.lookupFormatter(formatType);
       }
     }).readOnly(),
 
@@ -59,7 +52,7 @@ function helperFactory(formatType, helperOptions = {}) {
         format = intl.getFormat(formatType, hash.format);
       }
 
-      return get(this, 'formatter').format(
+      return get(this, 'formatter').compute(
         value,
         assign(assign({}, format), hash),
         {

--- a/packages/ember-intl/addon/services/intl.js
+++ b/packages/ember-intl/addon/services/intl.js
@@ -28,19 +28,17 @@ function formatterProxy(formatType) {
       options = {};
     }
 
-    const owner = getOwner(this);
-    const formatter = owner.lookup(`ember-intl@formatter:format-${formatType}`);
+    const formatter = this.lookupFormatter(formatType);
 
     if (typeof options.format === 'string') {
       options = assign(this.getFormat(formatType, options.format), options);
     }
 
-
     if (!formats) {
       formats = get(this, 'formats');
     }
 
-    return formatter.format(value, options, {
+    return formatter.compute(value, options, {
       formats: formats,
       locale: options.locale || get(this, '_locale')
     });
@@ -58,6 +56,17 @@ const IntlService = Service.extend(Evented, {
       return get(this, '_locale');
     }
   }),
+
+  lookupFormatter(formatType) {
+    const owner = getOwner(this);
+    const lookupName = `formatter:format-${formatType}`;
+
+    if (owner.hasRegistration(lookupName)) {
+      return owner.lookup(lookupName);
+    }
+
+    return owner.lookup(`ember-intl@${lookupName}`);
+  },
 
   adapter: computed({
     get() {


### PR DESCRIPTION
Also related to #350 
* centralizes the lookupFormatter logic to the service
* renamed `format` to `compute` on the formatter base to get ready to make it public
* reduce `ember-intl/formatters/base` down to just the _current_ public interface