### PR TITLE
[WIP] Computed Property Macros

### DIFF
--- a/packages/ember-intl/addon/macros.js
+++ b/packages/ember-intl/addon/macros.js
@@ -1,0 +1,57 @@
+import Ember from 'ember';
+
+const { get, assert, computed } = Ember;
+const keys = Object.keys;
+
+function extractDependencies(obj) {
+  return keys(obj)
+    .map(key => obj[key])
+    .filter(value => value.isReference)
+    .map(it => it.key);
+}
+
+function resolve(context, value) {
+  return value.isReference ? get(context, value.key) : value;
+}
+
+function resolveHash(context, hash) {
+  let result = {};
+
+  keys(hash).forEach(function(key) {
+    result[key] = resolve(context, hash[key]);
+  });
+
+  return result;
+}
+
+export function raw(value) {
+  return { value, isRaw: true };
+}
+
+export function ref(key) {
+  return { key, isReference: true };
+}
+
+/**
+ * Creates a computed property that calls `intl.formatNumber()`
+ *
+ * @param ref name of another property on the object (or a number wrapped with `raw()`)
+ * @param options static options hash (use `ref()` to reference other properties on the object)
+ */
+export function formatNumber(ref, options) {
+  let hash = options || Object.create(null);
+  let dependentKeys = extractDependencies(hash);
+  if (!ref.isRaw) {
+    dependentKeys.push(ref);
+  }
+  dependentKeys.push('intl.locale');
+
+  return computed(...dependentKeys, function() {
+    let intl = get(this, 'intl');
+    assert(`${this} does not have an 'intl' property set. Try: intl: Ember.inject.service()`, intl);
+
+    let number = ref.isRaw ? ref.value : get(this, ref);
+    let options = resolveHash(this, hash);
+    return intl.formatNumber(number, options);
+  }).readOnly();
+}

--- a/packages/ember-intl/tests/unit/macros/format-number-test.js
+++ b/packages/ember-intl/tests/unit/macros/format-number-test.js
@@ -1,0 +1,54 @@
+import Ember from 'ember';
+import { moduleFor, test } from 'ember-qunit';
+import { formatNumber, raw, ref } from 'ember-intl/macros';
+
+moduleFor('service:intl', 'Unit | Macro | formatNumber', {
+  integration: true,
+  beforeEach() {
+    let intl = this.subject();
+    intl.setLocale('en');
+
+    this.object = Ember.Object.extend({
+      intl,
+      someNumber: 12345,
+      fractionDigits: 3,
+      formattedNumber: formatNumber('someNumber'),
+      rawFormattedNumber: formatNumber(raw(10001)),
+      withFraction: formatNumber('someNumber', {
+        minimumFractionDigits: 2,
+      }),
+      withDynamicFraction: formatNumber('someNumber', {
+        minimumFractionDigits: ref('fractionDigits'),
+      }),
+    }).create();
+  }
+});
+
+test('defines a computed property that formats a number', function(assert) {
+  assert.equal(this.object.get('formattedNumber'), '12,345');
+});
+
+test('defines a computed property that formats a raw number', function(assert) {
+  assert.equal(this.object.get('rawFormattedNumber'), '10,001');
+});
+
+test('defines a computed property that formats a number with static options', function(assert) {
+  assert.equal(this.object.get('withFraction'), '12,345.00');
+});
+
+test('defines a computed property that formats a number with dynamic options', function(assert) {
+  assert.equal(this.object.get('withDynamicFraction'), '12,345.000');
+  Ember.run(() => this.object.set('fractionDigits', 1));
+  assert.equal(this.object.get('withDynamicFraction'), '12,345.0');
+});
+
+test('defines a computed property with dependencies', function(assert) {
+  Ember.run(() => this.object.set('someNumber', 42));
+  assert.equal(this.object.get('formattedNumber'), '42');
+});
+
+test('defines a computed property that depends on the locale', function(assert) {
+  assert.equal(this.object.get('formattedNumber'), '12,345');
+  Ember.run(() => this.subject().setLocale('es'));
+  assert.equal(this.object.get('formattedNumber'), '12.345');
+});


### PR DESCRIPTION
This PR introduces a `formatNumber()` computed property macro as discussed in https://github.com/jasonmit/ember-intl/issues/392#issuecomment-257812181. This is marked WIP since I'd like to add more macros, but also because the discussion in #392 wasn't quite finished and I wanted to present a concrete proposal to discuss.

Resolves #392 