### PR TITLE
Adding t-html helper which is an alias for format-html-message

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,12 +246,12 @@ This is done by using the `{{l}}` (lowercase L) helper as a subexpression.  This
 This delegates to the `{{t}}` helper, but will first HTML-escape all of the hash argument values. This allows the `message` string to contain HTML and it will be considered safe since it's part of the template and not user-supplied data.
 
 ```hbs
-{{format-html-message 'product.html.info'
+{{t-html 'product.html.info'
   product='Apple watch'
   price=200
   deadline=yesterday}}
 
-{{format-html-message (l '<strong>{numPhotos}</strong>')
+{{t-html (l '<strong>{numPhotos}</strong>')
   numPhotos=(format-number num)}}
 ```
 

--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -25,8 +25,8 @@ moduleForComponent('x-product', 'XProductComponent', {
     'ember-intl@formatter:format-number', // optional
     'ember-intl@formatter:format-relative', // optional
     'helper:intl-get', // optional
-    'helper:format-message', // optional
-    'helper:format-html-message', // optional
+    'helper:t', // optional, if used then be sure to include the format-message formatter above
+    'helper:t-html', // optional, if used then be sure to include the format-html-message formatter above
     'helper:format-date', // optional
     'helper:format-time', // optional
     'helper:format-relative', // optional
@@ -34,8 +34,7 @@ moduleForComponent('x-product', 'XProductComponent', {
   ],
   setup() {
     instanceInitializer.initialize(this);
-    const intl = this.container.lookup('service:intl');
-    intl.set('locale', 'en-us');
+    this.container.lookup('service:intl').setLocale('en-us');
   }
 });
 

--- a/packages/ember-intl/app/helpers/t-html.js
+++ b/packages/ember-intl/app/helpers/t-html.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-intl/helpers/format-html-message';


### PR DESCRIPTION
I'll continue to support `format-html-message`, but removing references to it in the docs the same way we removed `format-message` in favor of `t`  and `intl-get` with `l`