### PR TITLE
ensure app is set

### DIFF
--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -31,8 +31,8 @@ module.exports = {
     this._super.included.apply(this, arguments);
 
     var app = this._findHost();
-    this.opts = this.intlConfig(app.env);
     this.app = app;
+    this.opts = this.intlConfig(app.env);
 
     var translationFolder = this.opts.inputPath;
     this.hasTranslationDir = existsSync(path.join(app.project.root, translationFolder));


### PR DESCRIPTION
I'm getting this error when using `ember-intl` within an addon:

```js
TypeError: Cannot read property 'project' of undefined
    at Class.module.exports.intlConfig (/home/null/code/affinity/stage/directions/text/node_modules/affinity-engine-translator-ember-intl/node_modules/ember-intl/index.js:165:36)
```

This PR simply sets `this.app` before calling `intlConfig`.