### PR TITLE
Adding a public API for seeing all available locales registered by translations

### DIFF
--- a/packages/ember-intl/addon/models/translation.js
+++ b/packages/ember-intl/addon/models/translation.js
@@ -8,6 +8,8 @@ import Ember from 'ember';
 const { get, set, deprecate } = Ember;
 
 const TranslationModel = Ember.Object.extend({
+  localeName: null,
+
   init() {
     this._super(...arguments);
 

--- a/packages/ember-intl/addon/services/intl.js
+++ b/packages/ember-intl/addon/services/intl.js
@@ -1,5 +1,3 @@
-/* global requirejs */
-
 /**
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
@@ -12,11 +10,10 @@ import IntlRelativeFormat from 'intl-relativeformat';
 import isArrayEqual from '../utils/is-equal';
 
 const { assert, getOwner, computed, makeArray, get, set, RSVP, Service, Evented, deprecate } = Ember;
-const TRANSLATION_PATH_CAPTURE = /\/translations\/(.+)$/;
 const assign = Ember.assign || Ember.merge;
 
 function formatterProxy(formatType) {
-  return function (value, options, formats) {
+  return function(value, options, formats) {
     if (!options) {
       if (arguments.length > 1) {
         Ember.warn(`[ember-intl] expected object for formatter ${formatType} but received ${typeof options}`, false, {
@@ -57,6 +54,16 @@ const IntlService = Service.extend(Evented, {
       return get(this, '_locale');
     }
   }),
+
+  /**
+   * Returns an array of registered locale names
+   *
+   * @property locales
+   * @public
+   */
+  locales: computed('adapter.seen.[]', function() {
+    return get(this, 'adapter.seen').map(l => l.localeName);
+  }).readOnly(),
 
   adapter: computed({
     get() {
@@ -106,15 +113,11 @@ const IntlService = Service.extend(Evented, {
   },
 
   getLocalesByTranslations() {
-    return Object.keys(requirejs.entries).reduce((translations, module) => {
-      const match = module.match(TRANSLATION_PATH_CAPTURE);
+    deprecate('[ember-intl] `getLocalesByTranslations` is deprecated, use `locales` computed property', false, {
+      id: 'ember-intl-locales-cp'
+    });
 
-      if (match) {
-        translations.addObject(match[1]);
-      }
-
-      return translations;
-    }, Ember.A());
+    return get(this, 'locales');
   },
 
   /**

--- a/packages/ember-intl/blueprints/ember-intl-config/index.js
+++ b/packages/ember-intl/blueprints/ember-intl-config/index.js
@@ -8,5 +8,5 @@
 module.exports = {
   description: 'Create a new boilerplate configuration file',
 
-  normalizeEntityName: function () {}
+  normalizeEntityName() {}
 };

--- a/packages/ember-intl/blueprints/ember-intl-dot-notation/index.js
+++ b/packages/ember-intl/blueprints/ember-intl-dot-notation/index.js
@@ -8,5 +8,5 @@
 module.exports = {
   description: 'Used to support dot notated translation keys',
 
-  normalizeEntityName: function () {}
+  normalizeEntityName() {}
 };

--- a/packages/ember-intl/blueprints/ember-intl/index.js
+++ b/packages/ember-intl/blueprints/ember-intl/index.js
@@ -8,9 +8,9 @@
 module.exports = {
   description: 'Setup ember-intl',
 
-  normalizeEntityName: function () {},
+  normalizeEntityName() {},
 
-  afterInstall: function() {
+  afterInstall() {
     this.ui.writeLine(
       '[ember-intl] Don\'t forget to setup your application-wide locale.  ' +
       'Documentation: https://github.com/jasonmit/ember-intl#setting-runtime-locale'

--- a/packages/ember-intl/blueprints/translation/index.js
+++ b/packages/ember-intl/blueprints/translation/index.js
@@ -13,7 +13,7 @@ var isSupportedLocale = require('../../lib/utils/is-supported-locale');
 module.exports = {
   description: 'Adds an empty translation file and locale is supported',
 
-  normalizeEntityName: function(locale) {
+  normalizeEntityName(locale) {
     if (!locale) {
       throw new SilentError('[ember-intl] no locale argument provided. Usage: `ember g translation en-us`');
     }
@@ -21,7 +21,7 @@ module.exports = {
     return locale.toLowerCase();
   },
 
-  beforeInstall: function(options) {
+  beforeInstall(options) {
     var locale = options.entity.name;
 
     if (!isSupportedLocale(locale.toLowerCase())) {
@@ -30,9 +30,9 @@ module.exports = {
     }
   },
 
-  fileMapTokens: function() {
+  fileMapTokens() {
     return {
-      __name__: function(options) {
+      __name__(options) {
         return options.dasherizedModuleName
       }
     }

--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -242,7 +242,7 @@ module.exports = {
     let addons = this.app.project.addons;
     let registered = new Set();
 
-    let find = function (list, addon) {
+    let find = function(list, addon) {
       // Only handle each addon once
       if (registered.has(addon.name)) {
         return list;

--- a/packages/ember-intl/lib/broccoli/translation-reducer.js
+++ b/packages/ember-intl/lib/broccoli/translation-reducer.js
@@ -40,7 +40,7 @@ function propKeys(object) {
 
     if (object.hasOwnProperty(key)) {
       if (typeof object[key] === 'object') {
-        result = result.concat(propKeys(object[key]).map(function (_key) {
+        result = result.concat(propKeys(object[key]).map(function(_key) {
           return escaped + '.' + _key;
         }));
       } else {
@@ -120,7 +120,7 @@ class TranslationReducer extends CachingWriter {
       return 1;
     });
 
-    return sortedPaths.reduce(function (translations, file) {
+    return sortedPaths.reduce(function(translations, file) {
       let fullPath = inputPath + '/' + file;
 
       if (fs.statSync(fullPath).isDirectory()) {

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -62,7 +62,6 @@
     "broccoli-stew": "^1.2.0",
     "chalk": "^1.0.0",
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-import-polyfill": "^0.2.0",
     "ember-getowner-polyfill": "1.1.1",
     "ember-intl-format-cache": "^2.4.0",
     "ember-intl-messageformat": "^2.4.0",


### PR DESCRIPTION
Related to #411, fixing how translations are discovered to include support for lazily-loaded translations.  Also adds a new public API which is a computed property called `locales` on the intl service.  I've deprecated `findLocalesByTranslations` in favor of `locales`.