### PR TITLE
Patch lookup bug

### DIFF
--- a/packages/ember-intl/addon/adapters/default.js
+++ b/packages/ember-intl/addon/adapters/default.js
@@ -8,72 +8,73 @@ import Translation from '../models/translation';
 
 const { assert, A:emberArray, getOwner } = Ember;
 
-function normalize(fullName) {
-  assert('Lookup name must be a string', typeof fullName === 'string');
-
-  return fullName.toLocaleLowerCase();
-}
-
 const DefaultIntlAdapter = Ember.Object.extend({
   seen: null,
-  owner: null,
 
   init() {
     this._super(...arguments);
-
     this.seen = emberArray();
-    this.owner = getOwner(this);
   },
 
-  translationsFor(localeName) {
-    if (typeof localeName !== 'string') {
-      throw new Error('locale name required for translation lookup');
-    }
+  normalizeLocaleName(localeName) {
+    assert('Locale name must be a string', typeof localeName === 'string');
 
-    const normalizedLocale = normalize(localeName);
-    const Klass = this.owner._lookupFactory('model:ember-intl-translation') || Translation;
+    return localeName.toLocaleLowerCase();
+  },
+
+  lookupLocale(localeName) {
+    return this.seen.findBy('localeName', this.normalizeLocaleName(localeName));
+  },
+
+  localeFactory(localeName) {
+    const owner = getOwner(this);
+    const normalizedLocale = this.normalizeLocaleName(localeName);
     const lookupName = `ember-intl@translation:${normalizedLocale}`;
-    const exists = this.owner.hasRegistration(lookupName);
+    let model = owner.lookup(lookupName);
 
-    if (!exists) {
-      const ModelKlass = Klass.extend();
-
-      Object.defineProperty(ModelKlass.proto(), 'localeName', {
-        writable: false,
-        enumerable: true,
-        value: normalizedLocale
-      });
-
-      this.owner.register(lookupName, ModelKlass);
+    if (model) {
+      return model;
     }
 
-    const model = this.owner.lookup(lookupName);
+    const Klass = owner._lookupFactory('model:ember-intl-translation') || Translation;
+    const ModelKlass = Klass.extend();
 
-    if (!exists) {
-      this.seen.pushObject(model);
-    }
+    Object.defineProperty(ModelKlass.proto(), 'localeName', {
+      writable: false,
+      enumerable: true,
+      value: normalizedLocale
+    });
+
+    owner.register(lookupName, ModelKlass);
+    model = owner.lookup(lookupName);
+    this.seen.pushObject(model);
 
     return model;
   },
 
   has(localeName, translationKey) {
-    const model = this.translationsFor(localeName);
+    const model = this.lookupLocale(localeName);
 
     return model && model.has(translationKey);
   },
 
-  findTranslationByKey(localeNames, translationKey) {
-    const len = localeNames.length;
-    let i = 0;
-
-    for (; i < len; i++) {
-      const locale = localeNames[i];
-      const model = this.translationsFor(locale);
+  lookup(localeNames, translationKey) {
+    for (let i=0; i<localeNames.length; i++) {
+      const localeName = localeNames[i];
+      const model = this.lookupLocale(localeName);
 
       if (model && model.has(translationKey)) {
         return model.getValue(translationKey);
       }
     }
+  },
+
+  translationsFor() {
+    return this.localeFactory(...arguments);
+  },
+
+  findTranslationByKey() {
+    return this.lookup(...arguments);
   }
 });
 

--- a/packages/ember-intl/addon/helpers/format-message.js
+++ b/packages/ember-intl/addon/helpers/format-message.js
@@ -8,14 +8,16 @@ import Ember from 'ember';
 import factory from './-format-base';
 import { LiteralWrapper } from './l';
 
-const { get } = Ember;
+const { get, assert } = Ember;
 
-export function getValue([key], hash) {
+export function getValue([key], { locale:optionalLocale }) {
   if (key && key instanceof LiteralWrapper) {
     return key.value;
   }
 
-  return get(this, 'intl').findTranslationByKey(key, hash.locale);
+  assert('[ember-intl] translation lookup attempted but no translation key was provided.', key);
+
+  return get(this, 'intl').lookup(key, optionalLocale);
 }
 
 export default factory('message').extend({

--- a/packages/ember-intl/addon/helpers/intl-get.js
+++ b/packages/ember-intl/addon/helpers/intl-get.js
@@ -23,7 +23,7 @@ const IntlGetHelper = Helper.extend({
   },
 
   compute(params, hash = {}) {
-    return new LiteralWrapper(get(this, 'intl').findTranslationByKey(params[0], hash.locale));
+    return new LiteralWrapper(get(this, 'intl').lookup(params[0], hash.locale));
   },
 
   destroy(...args) {

--- a/packages/ember-intl/tests/unit/helpers/format-message-test.js
+++ b/packages/ember-intl/tests/unit/helpers/format-message-test.js
@@ -181,6 +181,7 @@ test('exists returns true when key found', function(assert) {
 
 test('able to discover all register translations', function(assert) {
   assert.expect(2);
+  service.exists('test', 'fr-ca');
   assert.equal(service.getLocalesByTranslations().join('; '), 'en-us; es-es; fr-fr');
   assert.equal(get(service, 'locales').join('; '), 'en-us; es-es; fr-fr');
 });


### PR DESCRIPTION
From the change in 2.17.0 brought a bug where a lookup of a translation would result in the creation of a locale model if one did not exist.  This is not the intended behavior.