### PR TITLE
Removing the need for an instance initializer

### DIFF
--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -2,29 +2,16 @@
 Integration Testing
 ==============================================================================
 
-Like unit tests, integration tests do not invoke the initializers.  This is
-why we need to implement a setup hook to manually invoke the initializer for
-ember-intl.  The initializer's role is to register all of the helpers
-(format-message, format-time, etc.)
-
-Unlike unit tests, dependencies are registered on the container by default.
-Therefor we can omit the `needs` property which specifies dependencies.
-For this reason, integration tests are the recommended method for testing
-with ember-intl.  That said, ember-intl is capable of being unit testable.
-
 ```js
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import { moduleForComponent, test } from 'ember-qunit';
-import instanceInitializer from 'app/instance-initializers/ember-intl'; /* "app" modulePrefix may vary */
 
 let service;
 
 moduleForComponent('x-product', 'XProductComponent', {
   integration: true,
   setup() {
-    // manually invoke the ember-intl initializer
-    instanceInitializer.initialize(this);
     service = this.container.lookup('service:intl');
     service.setLocale('en-us');
   }

--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -11,7 +11,6 @@ out [ember-intl-example](https://github.com/jasonmit/ember-intl-example/tree/mas
 
 ```js
 import { moduleForComponent, test } from 'ember-qunit';
-import instanceInitializer from '../../instance-initializers/ember-intl';
 
 moduleForComponent('x-product', 'XProductComponent', {
   unit: true,
@@ -33,8 +32,8 @@ moduleForComponent('x-product', 'XProductComponent', {
     'helper:format-number' // optional
   ],
   setup() {
-    instanceInitializer.initialize(this);
-    this.container.lookup('service:intl').setLocale('en-us');
+    let service = this.container.lookup('service:intl');
+    service.setLocale('en-us');
   }
 });
 

--- a/packages/ember-intl/app/instance-initializers/ember-intl.js
+++ b/packages/ember-intl/app/instance-initializers/ember-intl.js
@@ -1,56 +1,17 @@
-/* globals requirejs, Intl */
-
 /**
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
 import Ember from 'ember';
-import ENV from '../config/environment';
-import links from 'ember-intl/utils/links';
-
-const { warn } = Ember;
-
-function filterBy(type) {
-  return Object.keys(requirejs._eak_seen).filter((key) => {
-    return key.indexOf(`${ENV.modulePrefix}\/${type}\/`) === 0;
-  });
-}
 
 export function instanceInitializer(instance) {
-  let service;
-
-  if (typeof instance.lookup === 'function') {
-    service = instance.lookup('service:intl');
-  } else {
-    service = instance.container.lookup('service:intl');
-  }
-
-  if (typeof Intl === 'undefined') {
-    warn(`[ember-intl] Intl API is unavailable in this environment.\nSee: ${links.polyfill}`, false, {
-      id: 'ember-intl-undefined-intljs'
-    });
-  }
-
-  const cldrs = filterBy('cldrs');
-
-  if (!cldrs.length) {
-    warn('[ember-intl] project is missing CLDR data\nIf you are asynchronously loading translation, see: ${links.asyncTranslations}.', false, {
-      id: 'ember-intl-missing-cldr-data'
-    });
-  } else {
-    cldrs.map((moduleName) => requirejs(moduleName, null, null, true)['default'])
-      .forEach((locale) => locale.forEach(service.addLocaleData));
-  }
-
-  filterBy('translations').forEach((moduleName) => {
-    const localeSplit = moduleName.split('\/');
-    const localeName = localeSplit[localeSplit.length - 1];
-    service.addTranslations(localeName, requirejs(moduleName, null, null, true)['default']);
+  Ember.deprecate('[ember-intl] instance initializer is deprecated, no longer necessary to call in testing.', false, {
+    id: 'ember-intl-instance-initalizer'
   });
 }
 
 export default {
   name: 'ember-intl',
-  initialize: instanceInitializer
+  initialize() {}
 }

--- a/packages/ember-intl/tests/unit/helpers/format-html-message-test.js
+++ b/packages/ember-intl/tests/unit/helpers/format-html-message-test.js
@@ -1,9 +1,7 @@
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import formatHtmlHelper from 'ember-intl/helpers/format-html-message';
-import Translation from 'ember-intl/models/translation';
 
-const locale = 'en-us';
 let service, registry;
 
 moduleForComponent('format-html-message', {
@@ -14,14 +12,14 @@ moduleForComponent('format-html-message', {
 
     registry.injection('formatter', 'intl', 'service:intl');
 
-    registry.register('ember-intl@translation:en-us', Translation.extend({
+    service.addTranslations('en-us', {
       foo: {
         bar: 'foo bar baz',
         baz: 'baz baz baz'
       }
-    }));
+    });
 
-    service.setLocale(locale);
+    service.setLocale('en-us');
   }
 });
 

--- a/packages/ember-intl/tests/unit/helpers/format-message-test.js
+++ b/packages/ember-intl/tests/unit/helpers/format-message-test.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import formatMessageHelper from 'ember-intl/helpers/format-message';
-import instanceInitializer from '../../../instance-initializers/ember-intl';
 
 const { get, set, computed, run, A:emberArray, Object:EmberObject } = Ember;
 
@@ -14,8 +13,6 @@ moduleForComponent('format-message', {
   beforeEach() {
     registry = this.registry || this.container;
     service = this.container.lookup('service:intl');
-
-    instanceInitializer.initialize(this);
 
     service.addTranslations('en-us', {
       foo: {

--- a/packages/ember-intl/tests/unit/helpers/format-relative-test.js
+++ b/packages/ember-intl/tests/unit/helpers/format-relative-test.js
@@ -1,15 +1,12 @@
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import formatRelativehelper from 'ember-intl/helpers/format-relative';
-import { instanceInitializer } from '../../../instance-initializers/ember-intl';
 
 let service, registry;
 
 moduleForComponent('format-relative', {
   integration: true,
   beforeEach() {
-    instanceInitializer(this);
-
     registry = this.registry || this.container;
     service = this.container.lookup('service:intl');
     service.setLocale('en-us');

--- a/packages/ember-intl/tests/unit/helpers/intl-get-test.js
+++ b/packages/ember-intl/tests/unit/helpers/intl-get-test.js
@@ -2,29 +2,23 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import intlGetHelper from 'ember-intl/helpers/intl-get';
-import Translation from 'ember-intl/models/translation';
 
-const locale = 'en-us';
-let service, registry;
+let service;
 
 moduleForComponent('intl-get', {
   integration: true,
   beforeEach() {
-    registry = this.registry || this.container;
     service = this.container.lookup('service:intl');
 
-    registry.register('ember-intl@translation:en-us', Translation.extend());
-    registry.register('ember-intl@translation:fr-fr', Translation.extend());
-
-    this.container.lookup('ember-intl@translation:en-us').addTranslations({
+    service.addTranslations('en-us', {
       greeting: 'Hello'
     });
 
-    this.container.lookup('ember-intl@translation:fr-fr').addTranslations({
+    service.addTranslations('fr-fr', {
       greeting: 'Bonjour'
     });
 
-    service.setLocale(locale);
+    service.setLocale('en-us');
   }
 });
 

--- a/packages/ember-intl/tests/unit/services/intl-test.js
+++ b/packages/ember-intl/tests/unit/services/intl-test.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 import { moduleFor, test } from 'ember-qunit';
-import instanceInitializer from '../../../instance-initializers/ember-intl';
 
 let service;
 
@@ -31,7 +30,6 @@ test('triggers notifyPropertyChange only when locale changes', function(assert) 
 
 test('waits for translations to load', function(assert) {
   assert.expect(1);
-  instanceInitializer.initialize(this);
 
   return wait().then(() => {
     assert.equal(service.t('product.title', {


### PR DESCRIPTION
Complicates the hell out of the test story, isn't needed inside of an initializer.