### PR TITLE
docs(README): Use correct syntax for TS injection declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import Component from '@glimmer/component';
 import type IntlService from 'ember-intl/services/intl';
 
 export default class ExampleComponent extends Component {
-  @service intl!: IntlService;
+  @service declare intl: IntlService;
 }
 ```
 


### PR DESCRIPTION
Service injections should use the `declare` syntax instead of definite initialization `!` syntax, because they can actually be "stomped" when using spec-compliant `useDefineForClassFields`, as discussed [here][1].

[1]: https://jamescdavis.com/declare-your-injections-or-risk-losing-them/