### PR TITLE
Documented stricter plural category validation in v8

### DIFF
--- a/docs/ember-intl/app/templates/docs/migration/v8.md
+++ b/docs/ember-intl/app/templates/docs/migration/v8.md
@@ -102,7 +102,7 @@ The following options have been removed.
 - `outputPath`
 - `requiresTranslation`
 - `stripEmptyTranslations`
-- `verbose`
+- `verbose` - Plural category validation is now always enabled (see [Stricter plural category validation](#stricter-plural-category-validation) in Features)
 
 In `v8`, `ember-intl` will continue to support these options:
 
@@ -116,46 +116,6 @@ const defaultConfig = {
   wrapTranslationsWithNamespace: false,
 };
 ```
-
-
-### Stricter plural category validation
-
-In `v7`, plural category validation only ran when the `verbose` build option was enabled. In `v8`, validation is always enabled and uses Unicode CLDR plural rules to ensure your translations use valid plural categories for each locale.
-
-This means some messages that worked in `v7` will now cause build errors if they use invalid plural categories for their locale.
-
-For example, Chinese and Japanese only support the `other` plural category. Using `one` will cause a validation error:
-
-```json
-// Before (v7) - worked but was incorrect
-{
-  "errors": "错误{count, plural, one {} other {}}"
-}
-```
-
-```json
-// After (v8) - correct
-{
-  "errors": "错误{count, plural, other {}}"
-}
-```
-
-If you need to handle specific counts, use exact number matching instead of plural categories:
-
-```json
-{
-  "errors": "错误{count, plural, =0 {无错误} =1 {1个错误} other {#个错误}}"
-}
-```
-
-Valid plural categories by language:
-- **English (en)**: `one`, `other`
-- **Chinese (zh)**: `other` only
-- **Japanese (ja)**: `other` only
-- **Arabic (ar)**: `zero`, `one`, `two`, `few`, `many`, `other`
-- **Polish (pl)**: `one`, `few`, `many`, `other`
-
-See [Unicode CLDR plural rules](https://cldr.unicode.org/index/cldr-spec/plural-rules) for the complete list of plural categories per language.
 
 
 ### Removed loading of translations
@@ -198,6 +158,46 @@ The method and the corresponding helper are called `formatRelativeTime()` and `{
 
 
 ## Features
+
+### Stricter plural category validation
+
+In `v7`, plural category validation only ran when the `verbose` build option was enabled. In `v8`, validation is always enabled and uses Unicode CLDR plural rules to ensure your translations use valid plural categories for each locale.
+
+This means some messages that worked in `v7` will now generate warnings if they use invalid plural categories for their locale. These warnings won't fail your build, but you should fix them to ensure correct internationalization.
+
+For example, Chinese and Japanese only support the `other` plural category. Using `one` will generate a validation warning:
+
+```json
+// Before (v7) - worked but was incorrect
+{
+  "errors": "错误{count, plural, one {} other {}}"
+}
+```
+
+```json
+// After (v8) - correct
+{
+  "errors": "错误{count, plural, other {}}"
+}
+```
+
+If you need to handle specific counts, use exact number matching instead of plural categories:
+
+```json
+{
+  "errors": "错误{count, plural, =0 {无错误} =1 {1个错误} other {#个错误}}"
+}
+```
+
+Valid plural categories by language:
+- **English (en)**: `one`, `other`
+- **Chinese (zh)**: `other` only
+- **Japanese (ja)**: `other` only
+- **Arabic (ar)**: `zero`, `one`, `two`, `few`, `many`, `other`
+- **Polish (pl)**: `one`, `few`, `many`, `other`
+
+See [Unicode CLDR plural rules](https://cldr.unicode.org/index/cldr-spec/plural-rules) for the complete list of plural categories per language.
+
 
 ### V2 addon
 


### PR DESCRIPTION
## Why?
In v8, plural category validation changed from optional (via `verbose` flag) to always-on. Users upgrading from v7 encounter build errors like "Unknown plural categories: one" for Chinese and Japanese translations because these languages only support the `other` plural category per Unicode CLDR rules.

## Solution?
  Added documentation to the v8 migration guide explaining:
  - Why validation now fails for previously-allowed plural categories
  - How to fix messages (e.g. remove `one` category for zh/ja locales)
  - Valid plural categories for common languages
