### PR TITLE
add trustHTML as alias for htmlSafe

### DIFF
--- a/docs/ember-intl/app/templates/docs/helpers/format-message.md
+++ b/docs/ember-intl/app/templates/docs/helpers/format-message.md
@@ -63,15 +63,17 @@ Currently, `ember-intl` allows you to pass a string instead. If possible, avoid 
 ```hbs
 {{format-message
   "<em>{numPhotos, number} photos taken.</em>"
-  htmlSafe=true
+  trustHTML=true
   numPhotos=3
 }}
 ```
 
 
-## options.htmlSafe
+## options.htmlSafe / options.trustHTML
 
-To render an HTML in a translation message, set `htmlSafe` to `true`.
+To render an HTML in a translation message, set `htmlSafe` (or its alias `trustHTML`) to `true`.
+
+> **Note:** `trustHTML` is an alias for `htmlSafe`, introduced to align with [Ember's naming convention](https://github.com/emberjs/ember.js/pull/20939). The name better reflects the behavior: you're marking the HTML content as trusted. Both options work identically.
 
 <DocsDemo as |demo|>
   <demo.example>

--- a/docs/ember-intl/app/templates/docs/helpers/t.md
+++ b/docs/ember-intl/app/templates/docs/helpers/t.md
@@ -91,16 +91,18 @@ Please check that all arguments are well-defined when using the `{{t}}` helper. 
 ```
 
 
-## options.htmlSafe
+## options.htmlSafe / options.trustHTML
 
-To render an HTML in a translation message, set `htmlSafe` to `true`. The `{{t}}` helper returns a `SafeString` (casted as `string` to improve DX).
+To render an HTML in a translation message, set `htmlSafe` (or its alias `trustHTML`) to `true`. The `{{t}}` helper returns a `SafeString` (casted as `string` to improve DX).
 
 **Warning: Do not use triple curly braces (e.g. `{{{t "call-to-action"}}}`), as it can allow XSS (cross-site scripting).**
 
 ```hbs
 {{! components/example.hbs }}
-{{t "ember.visit-homepage" htmlSafe=true}}
+{{t "ember.visit-homepage" trustHTML=true}}
 ```
+
+> **Note:** `trustHTML` is an alias for `htmlSafe`, introduced to align with [Ember's naming convention](https://github.com/emberjs/ember.js/pull/20939). The name better reflects the behavior: you're marking the HTML content as trusted. Both options work identically.
 
 ```yaml
 # translations/en-us.yaml

--- a/docs/ember-intl/app/templates/docs/services/intl-part-1.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-1.md
@@ -79,7 +79,7 @@ const output = this.intl.formatMessage(
 // '3 photos taken.'
 ```
 
-If the message has HTML and you want to render it in the template, set `htmlSafe` to `true`.
+If the message has HTML and you want to render it in the template, set `htmlSafe` (or its alias `trustHTML`) to `true`.
 
 ```ts
 const output = this.intl.formatMessage(
@@ -89,12 +89,14 @@ const output = this.intl.formatMessage(
     id: 'photoshoot-short-summary',
   },
   {
-    htmlSafe: true,
+    trustHTML: true, // or htmlSafe: true
     numPhotos: 3,
   },
 );
 // '<em>3 photos taken.</em>'
 ```
+
+> **Note:** `trustHTML` is an alias for `htmlSafe`, introduced to align with [Ember's naming convention](https://github.com/emberjs/ember.js/pull/20939). The name better reflects the behavior: you're marking the HTML content as trusted. Both options work identically.
 
 
 ### formatNumber()
@@ -146,11 +148,11 @@ const output = this.intl.t('hello.message', {
 // 'Hello, Zoey!'
 ```
 
-If the translation message has HTML and you want to render it in the template, set `htmlSafe` to `true`.
+If the translation message has HTML and you want to render it in the template, set `htmlSafe` (or its alias `trustHTML`) to `true`.
 
 ```ts
 const output = this.intl.t('ember.visit-legal', {
-  htmlSafe: true,
+  trustHTML: true, // or htmlSafe: true
   url: 'https://emberjs.com/about/legal',
 });
 // 'See our <a href="https://emberjs.com/about/legal">Terms and Conditions</a>.'

--- a/packages/ember-intl/src/services/intl.ts
+++ b/packages/ember-intl/src/services/intl.ts
@@ -184,6 +184,12 @@ export default class IntlService extends Service {
     options?: FormatMessageParameters[1] & {
       htmlSafe?: boolean;
       locale?: string;
+      /**
+       * Alias for `htmlSafe`. When `true`, the output will be treated as trusted HTML.
+       * This naming better reflects the behavior: we're trusting the HTML content.
+       * @see https://github.com/emberjs/ember.js/pull/20939
+       */
+      trustHTML?: boolean;
     },
   ): string {
     if (value === undefined || value === null) {
@@ -201,7 +207,7 @@ export default class IntlService extends Service {
             id: value,
           };
 
-    if (options?.htmlSafe) {
+    if (options?.htmlSafe || options?.trustHTML) {
       const output = formatMessage(
         intlShape,
         descriptor,
@@ -329,6 +335,12 @@ export default class IntlService extends Service {
     options?: FormatMessageParameters[1] & {
       htmlSafe?: boolean;
       locale?: string;
+      /**
+       * Alias for `htmlSafe`. When `true`, the output will be treated as trusted HTML.
+       * This naming better reflects the behavior: we're trusting the HTML content.
+       * @see https://github.com/emberjs/ember.js/pull/20939
+       */
+      trustHTML?: boolean;
     },
   ): string {
     const locales = options?.locale ? [options.locale] : this._locale!;

--- a/tests/ember-intl/tests/unit/services/intl/t-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl/t-test.ts
@@ -74,6 +74,35 @@ module('Unit | Service | intl > t()', function (hooks) {
     );
   });
 
+  test('options.trustHTML (alias for htmlSafe)', function (this: TestContext, assert) {
+    this.intl.addTranslations('en-us', {
+      legacy: `'<strong class="example">'Hello, {name}!'</strong>'`,
+      modern: `<strong class="example">Hello, {name}!</strong>`,
+    });
+
+    assert.strictEqual(
+      this.intl
+        .t('legacy', {
+          trustHTML: true,
+          name: '<em>Tom</em>',
+        })
+        .toString(),
+      '<strong class="example">Hello, &lt;em&gt;Tom&lt;/em&gt;!</strong>',
+      'trustHTML works with legacy syntax',
+    );
+
+    assert.strictEqual(
+      this.intl
+        .t('modern', {
+          trustHTML: true,
+          name: '<em>Tom</em>',
+        })
+        .toString(),
+      '<strong class="example">Hello, &lt;em&gt;Tom&lt;/em&gt;!</strong>',
+      'trustHTML works with modern syntax',
+    );
+  });
+
   test('options.locale', function (this: TestContext, assert) {
     assert.strictEqual(
       this.intl.t('smoke-tests.hello.message', {


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/pull/20939

### Service API (packages/ember-intl/src/services/intl.ts)

  - Added trustHTML?: boolean option to both formatMessage() and t() methods
  - Updated the logic to check options?.htmlSafe || options?.trustHTML
  - Added JSDoc comments referencing [Ember's PR #20939](https://github.com/emberjs/ember.js/pull/20939)

### Tests (tests/ember-intl/tests/unit/services/intl/t-test.ts)

  - Added a new test options.trustHTML (alias for htmlSafe) that verifies the alias works identically to htmlSafe

### Documentation Updates

  - docs/helpers/t.md: Updated section to options.htmlSafe / options.trustHTML with explanation and note about the alias
  - docs/helpers/format-message.md: Same updates as above
  - docs/services/intl-part-1.md: Updated both formatMessage() and t() examples to use trustHTML with comments showing htmlSafe also works

##  Usage

  Users can now use either option interchangeably:
```hbs
  {{! Both work identically }}
  {{t "my.key" htmlSafe=true}}
  {{t "my.key" trustHTML=true}}
```
```js
  // In JavaScript/TypeScript
  this.intl.t('my.key', { trustHTML: true });
  this.intl.t('my.key', { htmlSafe: true });
  ```
htmlSafe option remains fully supported for backwards compatibility, while trustHTML provides a 1:1 naming convention to the updated function name in the Ember API.