### PR TITLE
Skipped ember-beta and ember-canary to avoid issues with 7.0 pre-release

### DIFF
--- a/.changeset/eager-turtles-fry.md
+++ b/.changeset/eager-turtles-fry.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"test-app-for-ember-intl": patch
+---
+
+Skipped ember-beta and ember-canary to avoid issues with 7.0 pre-release

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v6
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v6
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v6
@@ -130,7 +130,7 @@ jobs:
 
       - id: set-test-matrix
         name: Set test matrix
-        run: echo "matrix=$(pnpx -s @embroider/try list)" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(pnpx @embroider/try list)" >> $GITHUB_OUTPUT
         working-directory: 'tests/ember-intl'
 
 
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v6
@@ -156,7 +156,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Make file changes
-        run: pnpm dlx @embroider/try apply ${{ matrix.name }}
+        run: pnpx @embroider/try apply ${{ matrix.name }}
         working-directory: 'tests/ember-intl'
 
       - name: Install dependencies
@@ -183,7 +183,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v6
@@ -221,7 +221,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v6
@@ -230,7 +230,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -246,7 +246,7 @@ jobs:
 
       - name: Deploy app
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
         env:
           name: github-pages
           url: ${{ steps.deployment.outputs.page_url }}

--- a/tests/ember-intl/.try.mjs
+++ b/tests/ember-intl/.try.mjs
@@ -1,63 +1,18 @@
-const dependenciesForCompatibility = {
-  // '@ember/optional-features': '^2.3.0',
-  // '@embroider/compat': '^4.1.13',
-  // 'ember-cli': '~6.10.0',
-  // 'ember-auto-import': '^2.12.0',
-};
-
-const filesForCompatibility = {
-  // 'config/optional-features.json': [
-  //   `{`,
-  //   `  "application-template-wrapper": false,`,
-  //   `  "default-async-observers": true,`,
-  //   `  "jquery-integration": false,`,
-  //   `  "no-implicit-route-model": true,`,
-  //   `  "template-only-glimmer-components": true`,
-  //   `}`,
-  // ].join('\n'),
-  // 'ember-cli-build.js': [
-  //   `const { compatBuild } = require('@embroider/compat');`,
-  //   `const EmberApp = require('ember-cli/lib/broccoli/ember-app');`,
-  //   ``,
-  //   `module.exports = async function (defaults) {`,
-  //   `  const { buildOnce } = await import('@embroider/vite');`,
-  //   ``,
-  //   `  const app = new EmberApp(defaults, {`,
-  //   `    'ember-cli-babel': {`,
-  //   `      enableTypeScriptTransform: true,`,
-  //   `    },`,
-  //   `  });`,
-  //   ``,
-  //   `  return compatBuild(app, buildOnce);`,
-  //   `};`,
-  // ].join('\n'),
-};
-
 export default {
   packageManager: 'pnpm',
   scenarios: [
     {
-      env: {
-        ENABLE_COMPAT_BUILD: true,
-      },
-      files: filesForCompatibility,
       name: 'ember-lts-4.12',
       npm: {
         devDependencies: {
-          ...dependenciesForCompatibility,
           'ember-source': '~4.12.0',
         },
       },
     },
     {
-      env: {
-        ENABLE_COMPAT_BUILD: true,
-      },
-      files: filesForCompatibility,
       name: 'ember-lts-5.12',
       npm: {
         devDependencies: {
-          ...dependenciesForCompatibility,
           'ember-source': '~5.12.0',
         },
       },

--- a/tests/ember-intl/.try.mjs
+++ b/tests/ember-intl/.try.mjs
@@ -33,21 +33,21 @@ export default {
         },
       },
     },
-    {
-      name: 'ember-beta',
-      npm: {
-        devDependencies: {
-          'ember-source': 'npm:ember-source@beta',
-        },
-      },
-    },
-    {
-      name: 'ember-canary',
-      npm: {
-        devDependencies: {
-          'ember-source': 'npm:ember-source@alpha',
-        },
-      },
-    },
+    // {
+    //   name: 'ember-beta',
+    //   npm: {
+    //     devDependencies: {
+    //       'ember-source': 'npm:ember-source@beta',
+    //     },
+    //   },
+    // },
+    // {
+    //   name: 'ember-canary',
+    //   npm: {
+    //     devDependencies: {
+    //       'ember-source': 'npm:ember-source@alpha',
+    //     },
+    //   },
+    // },
   ],
 };


### PR DESCRIPTION
## Background

`ember-beta` currently fails to complete.

https://github.com/ijlee2/embroider-css-modules/actions/runs/23847150411/job/69517247928


```sh
Run pnpm test

> test-app-for-embroider-css-modules@2.1.2 test /home/runner/work/embroider-css-modules/embroider-css-modules/tests/embroider-css-modules
> vite build --mode test && ember test --config-file "./testem.cjs" --path dist --test-port 0

vite v8.0.3 building client environment for test...
Building
Environment: test
building... 
cleaning up
cleaning up...
Built project successfully. Stored in "/home/runner/work/embroider-css-modules/embroider-css-modules/tests/embroider-css-modules/tmp/compat-prebuild".

<script src="/testem.js"> in "/tests/index.html" can't be bundled without type="module" attribute
<script src="/@embroider/virtual/vendor.js"> in "/tests/index.html" can't be bundled without type="module" attribute
<script src="/@embroider/virtual/test-support.js"> in "/tests/index.html" can't be bundled without type="module" attribute
<script src="/@embroider/virtual/vendor.js"> in "/index.html" can't be bundled without type="module" attribute

/@embroider/virtual/app.css doesn't exist at build time, it will remain unchanged to be resolved at runtime
Error: The operation was canceled.
```
