### PR TITLE
Marked 7.5.0 as the latest v7

### DIFF
--- a/docs/ember-intl/src/docs/migration/past-documentations.md
+++ b/docs/ember-intl/src/docs/migration/past-documentations.md
@@ -2,7 +2,7 @@
 
 These links may provide help if you are on an older version of `ember-intl`.
 
-- [7.x](https://github.com/ember-intl/ember-intl/tree/v7.4.1/docs/ember-intl/app/templates/docs)
+- [7.x](https://github.com/ember-intl/ember-intl/tree/v7.5.0/docs/ember-intl/app/templates/docs)
 - [6.x](https://github.com/ember-intl/ember-intl/tree/v6.5.6/docs/ember-intl/app/templates/docs)
 - [5.x](https://github.com/ember-intl/ember-intl/tree/v5.7.0/tests/dummy/app/pods/docs)
 - [4.x](https://github.com/ember-intl/ember-intl/tree/v4.4.1/tests/dummy/app/pods/docs)

--- a/packages/ember-intl/CHANGELOG.md
+++ b/packages/ember-intl/CHANGELOG.md
@@ -92,7 +92,6 @@
 
 ### Minor Changes
 
-- [#2019](https://github.com/ember-intl/ember-intl/pull/2019) Created {{t-key}} helper ([@ijlee2](https://github.com/ijlee2))
 - [#1975](https://github.com/ember-intl/ember-intl/pull/1975) Converted ember-intl to v2 addon ([@ijlee2](https://github.com/ijlee2))
 
 ### Patch Changes
@@ -103,6 +102,12 @@
 - [#2017](https://github.com/ember-intl/ember-intl/pull/2017) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 - [#2007](https://github.com/ember-intl/ember-intl/pull/2007) Refactored utilities for lib ([@ijlee2](https://github.com/ijlee2))
 - [#2004](https://github.com/ember-intl/ember-intl/pull/2004) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+
+## 7.5.0
+
+### Minor Changes
+
+- [#2019](https://github.com/ember-intl/ember-intl/pull/2019) Created {{t-key}} helper ([@ijlee2](https://github.com/ijlee2))
 
 ## 7.4.1
 


### PR DESCRIPTION
## Why?

Follows up on releasing https://github.com/ember-intl/ember-intl/releases/tag/v7.5.0.
