### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/perky-moons-sleep.md
+++ b/.changeset/perky-moons-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ember-intl/lint": minor
+---
+
+Fixed lint errors

--- a/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 type Decorator = ReturnType<typeof AST.builders.decorator>;
@@ -32,6 +31,7 @@ export function findDependencies(file: string, data: Data): Dependencies {
 
   traverse(file, {
     visitClassProperty(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const decorators = node.value.decorators as Decorator[] | undefined;
 
       if (decorators === undefined || decorators.length !== 1) {
@@ -58,6 +58,7 @@ export function findDependencies(file: string, data: Data): Dependencies {
             return false;
           }
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           dependencies.services.intl = node.value.key.name as string;
 
           break;
@@ -69,12 +70,15 @@ export function findDependencies(file: string, data: Data): Dependencies {
           }
 
           if (
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             node.value.key.type !== 'Identifier' ||
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             node.value.key.name !== 'intl'
           ) {
             return false;
           }
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           dependencies.services.intl = node.value.key.name as string;
 
           break;
@@ -85,40 +89,47 @@ export function findDependencies(file: string, data: Data): Dependencies {
     },
 
     visitImportDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (data.isTypeScript && node.value.importKind !== 'value') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const importPath = node.value.source.value;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const specifiers = node.value.specifiers;
 
       switch (importPath) {
         case 'ember-intl': {
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           const t = specifiers.find((specifier) => {
             return (
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.type === 'ImportSpecifier' &&
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.imported.name === 't'
             );
           });
 
           if (t) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             dependencies.helpers.t = t.local.name as string;
           }
 
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           const tKey = specifiers.find((specifier) => {
             return (
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.type === 'ImportSpecifier' &&
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.imported.name === 'tKey'
             );
           });
 
           if (tKey) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             dependencies.helpers.tKey = tKey.local.name as string;
           }
 
@@ -127,15 +138,18 @@ export function findDependencies(file: string, data: Data): Dependencies {
 
         case 'ember-intl/helpers/t': {
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           const t = specifiers.find((specifier) => {
             return (
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.type === 'ImportDefaultSpecifier' &&
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.local.type === 'Identifier'
             );
           });
 
           if (t) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             dependencies.helpers.t = t.local.name as string;
           }
 
@@ -144,15 +158,18 @@ export function findDependencies(file: string, data: Data): Dependencies {
 
         case 'ember-intl/helpers/t-key': {
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           const tKey = specifiers.find((specifier) => {
             return (
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.type === 'ImportDefaultSpecifier' &&
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.local.type === 'Identifier'
             );
           });
 
           if (tKey) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             dependencies.helpers.tKey = tKey.local.name as string;
           }
 

--- a/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
@@ -30,9 +30,9 @@ export function findDependencies(file: string, data: Data): Dependencies {
   };
 
   traverse(file, {
-    visitClassProperty(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const decorators = node.value.decorators as Decorator[] | undefined;
+    visitClassProperty(path) {
+      // @ts-expect-error: Incorrect type
+      const decorators = path.node.decorators as Decorator[] | undefined;
 
       if (decorators === undefined || decorators.length !== 1) {
         return false;
@@ -58,8 +58,8 @@ export function findDependencies(file: string, data: Data): Dependencies {
             return false;
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          dependencies.services.intl = node.value.key.name as string;
+          // @ts-expect-error: Incorrect type
+          dependencies.services.intl = path.node.key.name as string;
 
           break;
         }
@@ -70,16 +70,13 @@ export function findDependencies(file: string, data: Data): Dependencies {
           }
 
           if (
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            node.value.key.type !== 'Identifier' ||
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            node.value.key.name !== 'intl'
+            path.node.key.type !== 'Identifier' ||
+            path.node.key.name !== 'intl'
           ) {
             return false;
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          dependencies.services.intl = node.value.key.name as string;
+          dependencies.services.intl = path.node.key.name;
 
           break;
         }
@@ -88,48 +85,39 @@ export function findDependencies(file: string, data: Data): Dependencies {
       return false;
     },
 
-    visitImportDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (data.isTypeScript && node.value.importKind !== 'value') {
+    visitImportDeclaration(path) {
+      if (data.isTypeScript && path.node.importKind !== 'value') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const importPath = node.value.source.value;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const specifiers = node.value.specifiers;
+      const importPath = path.node.source.value;
+      const specifiers = path.node.specifiers;
 
       switch (importPath) {
         case 'ember-intl': {
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           const t = specifiers.find((specifier) => {
             return (
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.type === 'ImportSpecifier' &&
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.imported.name === 't'
             );
           });
 
           if (t) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            // @ts-expect-error: Incorrect type
             dependencies.helpers.t = t.local.name as string;
           }
 
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           const tKey = specifiers.find((specifier) => {
             return (
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.type === 'ImportSpecifier' &&
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.imported.name === 'tKey'
             );
           });
 
           if (tKey) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            // @ts-expect-error: Incorrect type
             dependencies.helpers.tKey = tKey.local.name as string;
           }
 
@@ -138,18 +126,16 @@ export function findDependencies(file: string, data: Data): Dependencies {
 
         case 'ember-intl/helpers/t': {
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           const t = specifiers.find((specifier) => {
             return (
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.type === 'ImportDefaultSpecifier' &&
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              // @ts-expect-error: Incorrect type
               specifier.local.type === 'Identifier'
             );
           });
 
           if (t) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            // @ts-expect-error: Incorrect type
             dependencies.helpers.t = t.local.name as string;
           }
 
@@ -158,18 +144,16 @@ export function findDependencies(file: string, data: Data): Dependencies {
 
         case 'ember-intl/helpers/t-key': {
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           const tKey = specifiers.find((specifier) => {
             return (
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               specifier.type === 'ImportDefaultSpecifier' &&
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              // @ts-expect-error: Incorrect type
               specifier.local.type === 'Identifier'
             );
           });
 
           if (tKey) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            // @ts-expect-error: Incorrect type
             dependencies.helpers.tKey = tKey.local.name as string;
           }
 

--- a/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/in-javascript.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/in-javascript.ts
@@ -3,31 +3,31 @@ import { AST } from '@codemod-utils/ast-javascript';
 import type { TranslationKey } from '../../../../types/index.js';
 import type { Dependencies } from './find-dependencies.js';
 
-type ExpressionStatement = ReturnType<typeof AST.builders.expressionStatement>;
-type Expression = ExpressionStatement['expression'];
+type ExpressionStatement = typeof AST.builders.expressionStatement;
+type ExpressionKind = Parameters<ExpressionStatement>[0];
 
 type Data = {
   dependencies: NonNullable<Dependencies>;
   isTypeScript: boolean;
 };
 
-function saveKeys(keys: TranslationKey[], node: Expression): void {
-  switch (node.type) {
+function saveKeys(keys: TranslationKey[], path: ExpressionKind): void {
+  switch (path.type) {
     case 'ConditionalExpression': {
-      saveKeys(keys, node.consequent);
-      saveKeys(keys, node.alternate);
+      saveKeys(keys, path.consequent);
+      saveKeys(keys, path.alternate);
       break;
     }
 
     case 'Literal':
     case 'StringLiteral': {
-      keys.push(node.value as TranslationKey);
+      keys.push(path.value as TranslationKey);
       break;
     }
 
     case 'TemplateLiteral': {
-      if (node.quasis[0]?.tail === true) {
-        keys.push(node.quasis[0].value.raw);
+      if (path.quasis[0]?.tail === true) {
+        keys.push(path.quasis[0].value.raw);
       }
       break;
     }
@@ -50,19 +50,16 @@ export function inJavascript(file: string, data: Data): TranslationKey[] {
   const keys: TranslationKey[] = [];
 
   traverse(file, {
-    visitCallExpression(node) {
-      this.traverse(node);
+    visitCallExpression(path) {
+      this.traverse(path);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (node.value.arguments.length === 0) {
+      if (path.node.arguments.length === 0) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      switch (node.value.callee.type) {
+      switch (path.node.callee.type) {
         case 'Identifier': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          const { name } = node.value.callee;
+          const { name } = path.node.callee;
 
           if (
             name !== dependencies.helpers.t &&
@@ -71,23 +68,21 @@ export function inJavascript(file: string, data: Data): TranslationKey[] {
             return false;
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-          saveKeys(keys, node.value.arguments[0]);
+          saveKeys(keys, path.node.arguments[0] as ExpressionKind);
 
           break;
         }
 
         case 'MemberExpression': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          const { object, property } = node.value.callee;
+          const { object, property } = path.node.callee;
 
           const isIntlService =
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             (object.type === 'Identifier' &&
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               object.name === dependencies.services.intl) ||
+            // @ts-expect-error: Incorrect type
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             (object.property?.type === 'Identifier' &&
+              // @ts-expect-error: Incorrect type
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               object.property.name === dependencies.services.intl);
 
@@ -95,13 +90,11 @@ export function inJavascript(file: string, data: Data): TranslationKey[] {
             return false;
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (property.type !== 'Identifier' || property.name !== 't') {
             return false;
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-          saveKeys(keys, node.value.arguments[0]);
+          saveKeys(keys, path.node.arguments[0] as ExpressionKind);
 
           break;
         }

--- a/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/in-javascript.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/in-javascript.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 import type { TranslationKey } from '../../../../types/index.js';
@@ -54,13 +53,15 @@ export function inJavascript(file: string, data: Data): TranslationKey[] {
     visitCallExpression(node) {
       this.traverse(node);
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (node.value.arguments.length === 0) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (node.value.callee.type) {
         case 'Identifier': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           const { name } = node.value.callee;
 
           if (
@@ -70,31 +71,36 @@ export function inJavascript(file: string, data: Data): TranslationKey[] {
             return false;
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
           saveKeys(keys, node.value.arguments[0]);
 
           break;
         }
 
         case 'MemberExpression': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           const { object, property } = node.value.callee;
 
           const isIntlService =
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             (object.type === 'Identifier' &&
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               object.name === dependencies.services.intl) ||
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             (object.property?.type === 'Identifier' &&
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               object.property.name === dependencies.services.intl);
 
           if (!isIntlService) {
             return false;
           }
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (property.type !== 'Identifier' || property.name !== 't') {
             return false;
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
           saveKeys(keys, node.value.arguments[0]);
 
           break;


### PR DESCRIPTION
## Why?

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
