### PR TITLE
Began testing ember-lts-6.12, ember-beta, and ember-canary scenarios

### DIFF
--- a/.changeset/slow-pants-wish.md
+++ b/.changeset/slow-pants-wish.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"test-app-for-ember-intl": patch
+---
+
+Began testing ember-lts-6.12, ember-beta, and ember-canary scenarios

--- a/tests/ember-intl/.try.mjs
+++ b/tests/ember-intl/.try.mjs
@@ -18,10 +18,10 @@ export default {
       },
     },
     {
-      name: 'ember-lts-6.8',
+      name: 'ember-lts-6.12',
       npm: {
         devDependencies: {
-          'ember-source': '~6.8.0',
+          'ember-source': '~6.12.0',
         },
       },
     },

--- a/tests/ember-intl/.try.mjs
+++ b/tests/ember-intl/.try.mjs
@@ -33,21 +33,21 @@ export default {
         },
       },
     },
-    // {
-    //   name: 'ember-beta',
-    //   npm: {
-    //     devDependencies: {
-    //       'ember-source': 'npm:ember-source@beta',
-    //     },
-    //   },
-    // },
-    // {
-    //   name: 'ember-canary',
-    //   npm: {
-    //     devDependencies: {
-    //       'ember-source': 'npm:ember-source@alpha',
-    //     },
-    //   },
-    // },
+    {
+      name: 'ember-beta',
+      npm: {
+        devDependencies: {
+          'ember-source': 'npm:ember-source@beta',
+        },
+      },
+    },
+    {
+      name: 'ember-canary',
+      npm: {
+        devDependencies: {
+          'ember-source': 'npm:ember-source@alpha',
+        },
+      },
+    },
   ],
 };


### PR DESCRIPTION
## Why?

Follows up on https://github.com/ember-intl/ember-intl/pull/2079 and https://github.com/ember-intl/ember-intl/pull/2128.


## What changed?

- Replaced `ember-lts-6.8` with `ember-lts-6.12`.
- Enabled `ember-beta` and `ember-canary` to show compatibility with `ember-source@7.0.0`.
