### PR TITLE
Updated test scripts for v2 apps

### DIFF
--- a/docs/my-v2-app-with-fallbacks/package.json
+++ b/docs/my-v2-app-with-fallbacks/package.json
@@ -26,7 +26,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "ember-tsc --noEmit",
     "start": "vite",
-    "test": "vite build --mode development && ember test --path dist --test-port 0"
+    "test": "NODE_ENV=development vite build --mode development && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/docs/my-v2-app-with-lazy-loaded-translations/package.json
+++ b/docs/my-v2-app-with-lazy-loaded-translations/package.json
@@ -26,7 +26,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "ember-tsc --noEmit",
     "start": "vite",
-    "test": "vite build --mode development && ember test --path dist --test-port 0"
+    "test": "NODE_ENV=development vite build --mode development && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/docs/my-v2-app-with-namespace-from-folders/package.json
+++ b/docs/my-v2-app-with-namespace-from-folders/package.json
@@ -26,7 +26,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "ember-tsc --noEmit",
     "start": "vite",
-    "test": "vite build --mode development && ember test --path dist --test-port 0"
+    "test": "NODE_ENV=development vite build --mode development && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/docs/my-v2-app/package.json
+++ b/docs/my-v2-app/package.json
@@ -26,7 +26,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "ember-tsc --noEmit",
     "start": "vite",
-    "test": "vite build --mode development && ember test --path dist --test-port 0"
+    "test": "NODE_ENV=development vite build --mode development && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/tests/ember-intl/package.json
+++ b/tests/ember-intl/package.json
@@ -26,7 +26,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "ember-tsc --noEmit",
     "start": "vite",
-    "test": "vite build --mode test && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
+    "test": "NODE_ENV=development vite build --mode development && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",


### PR DESCRIPTION
## Background

In https://github.com/ijlee2/embroider-css-modules/pull/247, I needed to [update the `test` script](https://github.com/emberjs/ember.js/issues/21374#issuecomment-4386885690) so that tests will pass on `ember-source@7.0.0`.

> It's important to note that `NODE_ENV` (`process.env.NODE_ENV`) and modes are two different concepts. Here's how different commands affect the `NODE_ENV` and mode:
>
> | Command                                              | NODE_ENV        | Mode            |
> | ---------------------------------------------------- | --------------- | --------------- |
> | `vite build`                                         | `"production"`  | `"production"`  |
> | `vite build --mode development`                      | `"production"`  | `"development"` |
> | `NODE_ENV=development vite build`                    | `"development"` | `"production"`  |
> | `NODE_ENV=development vite build --mode development` | `"development"` | `"development"` |
>
> https://vite.dev/guide/env-and-mode#node-env-and-modes
