### PR TITLE
feat(ember-intl): make `primaryLocale`  to have a definite type

### DIFF
--- a/.changeset/primary-locale-definite.md
+++ b/.changeset/primary-locale-definite.md
@@ -1,0 +1,10 @@
+---
+"ember-intl": minor
+---
+
+`IntlService.primaryLocale` is now typed as `string` (no longer `string | undefined`) and throws when accessed before `setLocale()` has been called with a valid locale. 
+An will be thrown error with a helpful message, instructing to make sure to `setLocale` before accessing any methods. 
+```js
+"ember-intl: locale is missing. Make sure to call `intl.setLocale(...)` first."
+```
+

--- a/packages/ember-intl/src/services/intl.ts
+++ b/packages/ember-intl/src/services/intl.ts
@@ -88,12 +88,16 @@ export default class IntlService extends Service {
     return Object.keys(this._intls);
   }
 
-  get primaryLocale(): string | undefined {
-    if (!this._locale) {
-      return;
+  get primaryLocale(): string {
+    const primary = this._locale?.[0];
+
+    if (!primary) {
+      throw new Error(
+        'ember-intl: locale is missing. Make sure to call `intl.setLocale(...)` first.',
+      );
     }
 
-    return this._locale[0];
+    return primary;
   }
 
   addTranslations(locale: string, translations: TranslationJson): void {
@@ -379,13 +383,12 @@ export default class IntlService extends Service {
 
   private updateDocumentLanguage(): void {
     const html = getHtmlElement(this);
-    const { primaryLocale } = this;
 
-    if (!html || !primaryLocale) {
+    if (!html) {
       return;
     }
 
-    html.setAttribute('lang', primaryLocale);
+    html.setAttribute('lang', this.primaryLocale);
   }
 
   private updateIntl(

--- a/tests/ember-intl/tests/unit/services/intl/getters-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl/getters-test.ts
@@ -1,6 +1,5 @@
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
-import { setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import { setupTest } from 'test-app-for-ember-intl/tests/helpers';
 
@@ -10,7 +9,6 @@ interface TestContext extends BaseTestContext {
 
 module('Unit | Service | intl > getters', function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function (this: TestContext) {
     this.intl = this.owner.lookup('service:intl');
@@ -21,6 +19,21 @@ module('Unit | Service | intl > getters', function (hooks) {
   });
 
   test('primaryLocale', function (this: TestContext, assert) {
+    this.intl.setLocale('en-us');
+
     assert.strictEqual(this.intl.primaryLocale, 'en-us');
+  });
+
+  test('primaryLocale returns first locale of fallback chain', function (this: TestContext, assert) {
+    this.intl.setLocale(['fr-ca', 'fr', 'en-us']);
+
+    assert.strictEqual(this.intl.primaryLocale, 'fr-ca');
+  });
+
+  test('primaryLocale throws when setLocale has not been called', function (this: TestContext, assert) {
+    assert.throws(
+      () => this.intl.primaryLocale,
+      /ember-intl: locale is missing\. Make sure to call `intl\.setLocale\(\.\.\.\)` first\./,
+    );
   });
 });


### PR DESCRIPTION
## Why?

`ember-intl` has changed the type of `primaryLocale` between versions, relaxing it to allow an `undefined` locale. However an `undefined` value means locales aren't set and any `intl` method will throw anyway.

## Solution?

This PR tightens the types back to either return a `string` or and `Error` saying to `setLocale` first.

