### PR TITLE
fix(v1-compat): funnel project translations folder to ignore non-translation files

### DIFF
--- a/.changeset/v1-compat-funnel-project-translations.md
+++ b/.changeset/v1-compat-funnel-project-translations.md
@@ -1,0 +1,5 @@
+---
+"@ember-intl/v1-compat": minor
+---
+
+Filter the project's `translations/` folder through the same funnel (`*.{json,yaml,yml}`) that is already applied to addon translation trees. Previously, non-translation files such as a `.gitkeep` placeholder used to keep an empty `translations/` folder in git would reach the translation reducer, which derived an empty locale from the filename and inserted a `["", {}]` entry in the inlined `translations.js`. At runtime, the `load-translations` initializer then called `intl.addTranslations("", {})`, which made `@formatjs/intl` throw `INVALID_CONFIG`. See [#2153](https://github.com/ember-intl/ember-intl/issues/2153).

--- a/packages/ember-intl-v1-compat/lib/broccoli/build-translation-tree.js
+++ b/packages/ember-intl-v1-compat/lib/broccoli/build-translation-tree.js
@@ -80,7 +80,10 @@ function buildTranslationTree(project, inputPath, treeGenerator) {
   const projectTranslations = join(project.root, inputPath);
 
   if (existsSync(projectTranslations)) {
-    trees.push(new WatchedDir(projectTranslations));
+    // Funnel so that non-translation files (e.g. a `.gitkeep` used to keep
+    // the folder in git) are filtered out before reaching the reducer. The
+    // addon translation trees above are already funneled the same way.
+    trees.push(funnelTranslations(new WatchedDir(projectTranslations)));
   }
 
   return [mergeTrees(trees, { overwrite: true }), addonsWithTranslations];

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/build-translation-tree/ignores-non-translation-files.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/build-translation-tree/ignores-non-translation-files.test.ts
@@ -1,0 +1,37 @@
+import { assert, loadFixture, test } from '@codemod-utils/tests';
+import buildTranslationTree from '@ember-intl/v1-compat/lib/broccoli/build-translation-tree.js';
+
+import { buildTranslationsDir } from '../../../helpers/index.js';
+
+test('lib | broccoli | build-translation-tree > ignores non-translation files in the project translations folder', async function () {
+  // Reproduces https://github.com/ember-intl/ember-intl/issues/2153
+  //
+  // An empty `.gitkeep` (used to keep an empty translations folder in git)
+  // must not be treated as a translation file. Otherwise it ends up in the
+  // merged tree, the reducer derives an empty locale from its filename, and
+  // the inlined `translations.js` array contains a `["", {}]` entry — which
+  // makes @formatjs/intl throw INVALID_CONFIG at runtime.
+  const inputProject = {
+    translations: {
+      '.gitkeep': '',
+      'en-us.json': `{ "no-arguments": "Hello world!" }`,
+    },
+  };
+
+  const projectRoot = 'tmp/broccoli_merge_trees';
+
+  loadFixture(inputProject, { projectRoot });
+
+  const project = {
+    addons: [],
+    root: projectRoot,
+  };
+
+  const [outputNode] = buildTranslationTree(project, 'translations', () => {});
+
+  const translationsDir = await buildTranslationsDir(outputNode);
+
+  assert.deepStrictEqual(translationsDir, {
+    'en-us.json': `{ "no-arguments": "Hello world!" }`,
+  });
+});


### PR DESCRIPTION
Fixes #2153.

## Summary

The addon translation trees built by `@ember-intl/v1-compat` are already funneled with an include filter of `*.{json,yaml,yml}`, but the project's own `translations/` folder was added to the merged tree as a `WatchedDir` without any filter. Any non-translation file (e.g. a `.gitkeep` placeholder used to keep an empty `translations/` folder in git) therefore reached the translation reducer, which derived an empty locale from the filename and produced a `["", {}]` entry at the head of the inlined `translations.js` array.

At runtime, the `load-translations` instance initializer then called `intl.addTranslations("", {})`, which made `@formatjs/intl` throw:

```
[@formatjs/intl Error INVALID_CONFIG] "locale" was not configured, using "" as fallback.
```

## Fix

Wrap the project tree with the same `funnelTranslations` helper that is already used for addon trees, so only `*.{json,yaml,yml}` files reach the reducer.

## Test

Added `tests/ember-intl-v1-compat/tests/lib/broccoli/build-translation-tree/ignores-non-translation-files.test.ts`. The test sets up a project with `translations/.gitkeep` (empty) alongside a real `en-us.json` and asserts the merged tree contains only the JSON file. Verified the test fails on `main` without the fix and passes with it.

## Changeset

Added a `minor` changeset for `@ember-intl/v1-compat`, per the issue discussion.