### PR TITLE
Recommended trustHTML for modern projects

### DIFF
--- a/.changeset/full-sheep-tie.md
+++ b/.changeset/full-sheep-tie.md
@@ -1,0 +1,5 @@
+---
+"docs-app-for-ember-intl": minor
+---
+
+Recommended trustHTML for modern projects

--- a/docs/ember-intl/src/docs/helpers/format-message.md
+++ b/docs/ember-intl/src/docs/helpers/format-message.md
@@ -50,7 +50,7 @@ For more information, see [Advanced - Auto-generating keys](../advanced/auto-gen
 
 ### htmlSafe {#options-html-safe}
 
-To render an HTML in a translation message, set `htmlSafe` to `true`.
+To render an HTML in a translation message, set `htmlSafe` to `true`. The `formatMessage` helper returns a `SafeString`, casted as `string` to improve DX.
 
 ::: code-group
 
@@ -61,3 +61,26 @@ To render an HTML in a translation message, set `htmlSafe` to `true`.
 <CodePreview src="/components/locale-switcher.gts">
   <CodePreview src="/snippets/helpers/format-message/example-2/component.gts" />
 </CodePreview>
+
+> [!TIP]
+>
+> If the version of your `ember-source` is `6.7` or above, use Ember's `trustHTML` instead.
+>
+> ::: code-group
+>
+> ```gts [app/components/example.gts]
+> import { trustHTML } from '@ember/template';
+> import { formatMessage } from 'ember-intl';
+> 
+> const descriptor = {
+>   defaultMessage: '<em>{numPhotos, number} photos taken.</em>',
+>   description: 'A short summary of the photoshoot from this week',
+>   id: 'photoshoot-short-summary',
+> };
+>
+> <template>
+>   {{trustHTML (formatMessage descriptor numPhotos=3)}}
+> </template>
+> ```
+>
+> :::

--- a/docs/ember-intl/src/docs/helpers/t.md
+++ b/docs/ember-intl/src/docs/helpers/t.md
@@ -174,7 +174,7 @@ To avoid this scenario, please ensure that all arguments are well-defined before
 
 ### htmlSafe {#options-html-safe}
 
-To render an HTML in a translation message, set `htmlSafe` to `true`. The `t` helper returns a `SafeString` (casted as `string` to improve DX).
+To render an HTML in a translation message, set `htmlSafe` to `true`. The `t` helper returns a `SafeString`, casted as `string` to improve DX.
 
 ::: code-group
 
@@ -191,6 +191,23 @@ visit-homepage: Visit <a href="https://www.emberjs.com">Ember.js</a>.
 ```
 
 :::
+
+> [!TIP]
+>
+> If the version of your `ember-source` is `6.7` or above, use Ember's `trustHTML` instead.
+>
+> ::: code-group
+>
+> ```gts [app/components/example.gts]
+> import { trustHTML } from '@ember/template';
+> import { t } from 'ember-intl';
+>
+> <template>
+>   {{trustHTML (t "visit-homepage")}}
+> </template>
+> ```
+>
+> :::
 
 > [!CAUTION]
 > 


### PR DESCRIPTION
## Background

Documented the suggestion made in https://github.com/ember-intl/ember-intl/pull/2021#issuecomment-3618515485.

Ember provides `trustHTML` helper since `6.7.0`. This makes the `htmlSafe=true` option for `formatMessage` and `t` helpers unnecessary.
