### PR TITLE
Supported buildOptions keys namespaceKeysByDir and translationsDir (Part 1)

### DIFF
--- a/.changeset/loose-regions-show.md
+++ b/.changeset/loose-regions-show.md
@@ -1,0 +1,6 @@
+---
+"@ember-intl/v1-compat": minor
+"test-ember-intl-v1-compat": minor
+---
+
+Supported buildOptions keys namespaceKeysByDir and translationsDir

--- a/packages/ember-intl-v1-compat/index.js
+++ b/packages/ember-intl-v1-compat/index.js
@@ -11,9 +11,9 @@ const findEngine = require('./lib/utils/ember-engine');
 
 const defaultBuildOptions = {
   fallbackLocale: undefined,
-  inputPath: 'translations',
+  namespaceKeysByDir: false,
   publicOnly: false,
-  wrapTranslationsWithNamespace: false,
+  translationsDir: 'translations',
 };
 
 module.exports = {
@@ -77,12 +77,12 @@ module.exports = {
   },
 
   getTranslationTree({ mergeTranslationFiles, outputPath }) {
-    const { fallbackLocale, inputPath, wrapTranslationsWithNamespace } =
+    const { fallbackLocale, namespaceKeysByDir, translationsDir } =
       this.buildOptions;
 
     const [translationTree, addonsWithTranslations] = buildTranslationTree(
       this.project,
-      inputPath,
+      translationsDir,
       this.treeGenerator,
     );
 
@@ -90,8 +90,8 @@ module.exports = {
       addonsWithTranslations,
       fallbackLocale,
       mergeTranslationFiles,
+      namespaceKeysByDir,
       outputPath,
-      wrapTranslationsWithNamespace,
     });
   },
 
@@ -106,16 +106,56 @@ module.exports = {
     }
 
     const userConfig = require(configFile)(environment);
-    const buildOptions = Object.keys(defaultBuildOptions);
+    const buildOptions = new Set([
+      ...Object.keys(defaultBuildOptions),
+      'fallbackLocale',
+      'inputPath',
+      'publicOnly',
+      'wrapTranslationsWithNamespace',
+    ]);
 
     for (const [buildOption, value] of Object.entries(userConfig)) {
-      if (!buildOptions.includes(buildOption)) {
+      if (!buildOptions.has(buildOption)) {
         throw new Error(
           `ERROR: Unable to read \`config/ember-intl.js\`. (unknown build option: ${buildOption})`,
         );
       }
 
-      config[buildOption] = value;
+      switch (buildOption) {
+        case 'inputPath': {
+          console.log(
+            'WARNING: `inputPath` will be replaced by `translationsDir` in @ember-intl/v1-compat@2.0.0. You can rename the key now to ease migration.',
+          );
+
+          config['translationsDir'] = value;
+
+          break;
+        }
+
+        case 'publicOnly': {
+          console.log(
+            'WARNING: `publicOnly` will be derived from `namespaceKeysByDir` (currently called `wrapTranslationsWithNamespace`) in @ember-intl/v1-compat@2.0.0. You do not need to take any action.',
+          );
+
+          config['publicOnly'] = value;
+
+          break;
+        }
+
+        case 'wrapTranslationsWithNamespace': {
+          console.log(
+            'WARNING: `wrapTranslationsWithNamespace` will be replaced by `namespaceKeysByDir` in @ember-intl/v1-compat@2.0.0. You can rename the key now to ease migration.',
+          );
+
+          config['namespaceKeysByDir'] = value;
+
+          break;
+        }
+
+        default: {
+          config[buildOption] = value;
+        }
+      }
     }
 
     return config;

--- a/packages/ember-intl-v1-compat/lib/broccoli/build-translation-tree.js
+++ b/packages/ember-intl-v1-compat/lib/broccoli/build-translation-tree.js
@@ -57,7 +57,7 @@ function processAddons(addons, options) {
   });
 }
 
-function buildTranslationTree(project, inputPath, treeGenerator) {
+function buildTranslationTree(project, translationsDir, treeGenerator) {
   const addonsWithTranslations = [];
   const translationTrees = [];
   const trees = [];
@@ -77,7 +77,7 @@ function buildTranslationTree(project, inputPath, treeGenerator) {
     );
   }
 
-  const projectTranslations = join(project.root, inputPath);
+  const projectTranslations = join(project.root, translationsDir);
 
   if (existsSync(projectTranslations)) {
     // Funnel so that non-translation files (e.g. a `.gitkeep` used to keep

--- a/packages/ember-intl-v1-compat/lib/broccoli/translation-reducer.js
+++ b/packages/ember-intl-v1-compat/lib/broccoli/translation-reducer.js
@@ -112,11 +112,11 @@ class TranslationReducer extends CachingWriter {
         return accumulator;
       }
 
-      if (this.options.wrapTranslationsWithNamespace === true) {
+      if (this.options.namespaceKeysByDir === true) {
         translationObject = namespaceKeys(translationObject, {
           addonNames: this.options.addonsWithTranslations,
           filePath,
-          inputPath: this.inputPaths[0],
+          translationsDir: this.inputPaths[0],
         });
       }
 

--- a/packages/ember-intl-v1-compat/lib/utils/translation-reducer/namespace-keys.js
+++ b/packages/ember-intl-v1-compat/lib/utils/translation-reducer/namespace-keys.js
@@ -7,13 +7,10 @@ const { dirname, normalize, sep } = require('node:path');
  * then `translationObject` will have `foo.bar.baz` instead.
  */
 function namespaceKeys(translations, data) {
-  const { addonNames, filePath, inputPath } = data;
+  const { addonNames, filePath, translationsDir } = data;
 
-  const normalizedFilePath = normalize(filePath);
-  const normalizedInputPath = normalize(inputPath);
-
-  const folderPath = dirname(normalizedFilePath).replace(
-    normalizedInputPath,
+  const folderPath = dirname(normalize(filePath)).replace(
+    normalize(translationsDir),
     '',
   );
 

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/ignores-unknown-locales.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/ignores-unknown-locales.test.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import { assert, loadFixture, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
@@ -12,13 +10,12 @@ test('lib | broccoli | translation-reducer | base case > ignores unknown locales
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
   const logs: string[] = [];
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     log: (message: string): void => {
       logs.push(message);
     },

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/it-works.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/it-works.test.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import { assert, loadFixture, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
@@ -12,11 +10,10 @@ test('lib | broccoli | translation-reducer | base case > it works', async functi
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath);
+  const outputNode = new TranslationReducer([projectRoot]);
 
   const translationsDir = await buildTranslationsDir(outputNode);
 

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/mergeTranslationFiles-is-true.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/mergeTranslationFiles-is-true.test.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import { assert, loadFixture, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
@@ -12,11 +10,10 @@ test('lib | broccoli | translation-reducer | base case > mergeTranslationFiles i
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     mergeTranslationFiles: true,
   });
 

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/fallbackLocale/does-not-overwrite-user-provided-translations.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/fallbackLocale/does-not-overwrite-user-provided-translations.test.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import { assert, loadFixture, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
@@ -12,11 +10,10 @@ test('lib | broccoli | translation-reducer | fallbackLocale > does not overwrite
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     fallbackLocale: 'en-us',
   });
 

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/fallbackLocale/falls-back-for-missing-translations.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/fallbackLocale/falls-back-for-missing-translations.test.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import { assert, loadFixture, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
@@ -12,11 +10,10 @@ test('lib | broccoli | translation-reducer | fallbackLocale > falls back for mis
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     fallbackLocale: 'en-us',
   });
 

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/edge-case-folder-name-has-space.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/edge-case-folder-name-has-space.test.ts
@@ -27,7 +27,7 @@ test('lib | broccoli | translation-reducer | mergeTranslations > edge case (fold
 
   const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: [],
-    wrapTranslationsWithNamespace: true,
+    namespaceKeysByDir: true,
   });
 
   // @ts-expect-error: Incorrect type

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/edge-case-folder-name-has-space.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/edge-case-folder-name-has-space.test.ts
@@ -22,20 +22,19 @@ test('lib | broccoli | translation-reducer | mergeTranslations > edge case (fold
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: [],
     wrapTranslationsWithNamespace: true,
   });
 
   // @ts-expect-error: Incorrect type
-  outputNode.inputPaths = [inputPath];
+  outputNode.inputPaths = [projectRoot];
 
   const translations = outputNode.mergeTranslations([
-    join(inputPath, '  things for  product /en-us.yaml'),
+    join(projectRoot, '  things for  product /en-us.yaml'),
   ]);
 
   assert.deepStrictEqual(translations, {

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/it-does-not-remove-empty-translations.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/it-does-not-remove-empty-translations.test.ts
@@ -21,17 +21,16 @@ test('lib | broccoli | translation-reducer | mergeTranslations > it does not rem
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: [],
   });
 
   const translations = outputNode.mergeTranslations([
-    join(inputPath, 'de-de.yaml'),
-    join(inputPath, 'en-us.yaml'),
+    join(projectRoot, 'de-de.yaml'),
+    join(projectRoot, 'en-us.yaml'),
   ]);
 
   assert.deepStrictEqual(translations, {

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-1.test.ts
@@ -23,21 +23,20 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: [],
   });
 
   let translations = outputNode.mergeTranslations([
     join(
-      inputPath,
+      projectRoot,
       '__ember-intl-addon__/my-v1-addon/components/hello/en-us.yaml',
     ),
-    join(inputPath, '__ember-intl-addon__/my-v1-addon/components/en-us.yaml'),
-    join(inputPath, '__ember-intl-addon__/my-v1-addon/en-us.yaml'),
+    join(projectRoot, '__ember-intl-addon__/my-v1-addon/components/en-us.yaml'),
+    join(projectRoot, '__ember-intl-addon__/my-v1-addon/en-us.yaml'),
   ]);
 
   assert.deepStrictEqual(translations, {
@@ -50,10 +49,10 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
 
   // Check order dependency
   translations = outputNode.mergeTranslations([
-    join(inputPath, '__ember-intl-addon__/my-v1-addon/en-us.yaml'),
-    join(inputPath, '__ember-intl-addon__/my-v1-addon/components/en-us.yaml'),
+    join(projectRoot, '__ember-intl-addon__/my-v1-addon/en-us.yaml'),
+    join(projectRoot, '__ember-intl-addon__/my-v1-addon/components/en-us.yaml'),
     join(
-      inputPath,
+      projectRoot,
       '__ember-intl-addon__/my-v1-addon/components/hello/en-us.yaml',
     ),
   ]);

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-1.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { assert, loadFixture, normalizeFile, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
-test('lib | broccoli | translation-reducer | mergeTranslations > translations from addon (wrapTranslationsWithNamespace is false)', function () {
+test('lib | broccoli | translation-reducer | mergeTranslations > translations from addon (namespaceKeysByDir is false)', function () {
   const inputProject = {
     '__ember-intl-addon__': {
       'my-v1-addon': {

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-2.test.ts
@@ -23,25 +23,24 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: ['my-v1-addon'],
     wrapTranslationsWithNamespace: true,
   });
 
   // @ts-expect-error: Incorrect type
-  outputNode.inputPaths = [inputPath];
+  outputNode.inputPaths = [projectRoot];
 
   const translations = outputNode.mergeTranslations([
     join(
-      inputPath,
+      projectRoot,
       '__ember-intl-addon__/my-v1-addon/components/hello/en-us.yaml',
     ),
-    join(inputPath, '__ember-intl-addon__/my-v1-addon/components/en-us.yaml'),
-    join(inputPath, '__ember-intl-addon__/my-v1-addon/en-us.yaml'),
+    join(projectRoot, '__ember-intl-addon__/my-v1-addon/components/en-us.yaml'),
+    join(projectRoot, '__ember-intl-addon__/my-v1-addon/en-us.yaml'),
   ]);
 
   assert.deepStrictEqual(translations, {

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-2.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { assert, loadFixture, normalizeFile, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
-test('lib | broccoli | translation-reducer | mergeTranslations > translations from addon (wrapTranslationsWithNamespace is true)', function () {
+test('lib | broccoli | translation-reducer | mergeTranslations > translations from addon (namespaceKeysByDir is true)', function () {
   const inputProject = {
     '__ember-intl-addon__': {
       'my-v1-addon': {
@@ -28,7 +28,7 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
 
   const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: ['my-v1-addon'],
-    wrapTranslationsWithNamespace: true,
+    namespaceKeysByDir: true,
   });
 
   // @ts-expect-error: Incorrect type

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-1.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { assert, loadFixture, normalizeFile, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
-test('lib | broccoli | translation-reducer | mergeTranslations > translations from app (wrapTranslationsWithNamespace is false)', function () {
+test('lib | broccoli | translation-reducer | mergeTranslations > translations from app (namespaceKeysByDir is false)', function () {
   const inputProject = {
     components: {
       hello: {

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-1.test.ts
@@ -19,18 +19,17 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: [],
   });
 
   let translations = outputNode.mergeTranslations([
-    join(inputPath, 'components/hello/en-us.yaml'),
-    join(inputPath, 'components/en-us.yaml'),
-    join(inputPath, 'en-us.yaml'),
+    join(projectRoot, 'components/hello/en-us.yaml'),
+    join(projectRoot, 'components/en-us.yaml'),
+    join(projectRoot, 'en-us.yaml'),
   ]);
 
   assert.deepStrictEqual(translations, {
@@ -43,9 +42,9 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
 
   // Check order dependency
   translations = outputNode.mergeTranslations([
-    join(inputPath, 'en-us.yaml'),
-    join(inputPath, 'components/en-us.yaml'),
-    join(inputPath, 'components/hello/en-us.yaml'),
+    join(projectRoot, 'en-us.yaml'),
+    join(projectRoot, 'components/en-us.yaml'),
+    join(projectRoot, 'components/hello/en-us.yaml'),
   ]);
 
   assert.deepStrictEqual(translations, {

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-2.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { assert, loadFixture, normalizeFile, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
-test('lib | broccoli | translation-reducer | mergeTranslations > translations from app (wrapTranslationsWithNamespace is true)', function () {
+test('lib | broccoli | translation-reducer | mergeTranslations > translations from app (namespaceKeysByDir is true)', function () {
   const inputProject = {
     components: {
       hello: {
@@ -24,7 +24,7 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
 
   const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: [],
-    wrapTranslationsWithNamespace: true,
+    namespaceKeysByDir: true,
   });
 
   // @ts-expect-error: Incorrect type

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-2.test.ts
@@ -19,22 +19,21 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     addonsWithTranslations: [],
     wrapTranslationsWithNamespace: true,
   });
 
   // @ts-expect-error: Incorrect type
-  outputNode.inputPaths = [inputPath];
+  outputNode.inputPaths = [projectRoot];
 
   const translations = outputNode.mergeTranslations([
-    join(inputPath, 'components/hello/en-us.yaml'),
-    join(inputPath, 'components/en-us.yaml'),
-    join(inputPath, 'en-us.yaml'),
+    join(projectRoot, 'components/hello/en-us.yaml'),
+    join(projectRoot, 'components/en-us.yaml'),
+    join(projectRoot, 'en-us.yaml'),
   ]);
 
   assert.deepStrictEqual(translations, {

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/outputPath/it-works.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/outputPath/it-works.test.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import { assert, loadFixture, test } from '@codemod-utils/tests';
 import TranslationReducer from '@ember-intl/v1-compat/lib/broccoli/translation-reducer.js';
 
@@ -12,11 +10,10 @@ test('lib | broccoli | translation-reducer | outputPath > it works', async funct
   };
 
   const projectRoot = 'tmp/broccoli_merge_trees';
-  const inputPath = join(projectRoot);
 
   loadFixture(inputProject, { projectRoot });
 
-  const outputNode = new TranslationReducer(inputPath, {
+  const outputNode = new TranslationReducer([projectRoot], {
     outputPath: 'custom/output/path',
   });
 

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/get-translations/file-extension-is-json.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/get-translations/file-extension-is-json.test.ts
@@ -13,11 +13,11 @@ test('lib | utils | translation-reducer | get-translations > file extension is .
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
-  let output = getTranslations(join(inputPath, 'de-de.json'));
+  let output = getTranslations(join(translationsDir, 'de-de.json'));
 
   assert.deepStrictEqual(output, {
     nested: {
@@ -26,7 +26,7 @@ test('lib | utils | translation-reducer | get-translations > file extension is .
     'no-arguments': 'Hallo Welt!',
   });
 
-  output = getTranslations(join(inputPath, 'es.json'));
+  output = getTranslations(join(translationsDir, 'es.json'));
 
   assert.deepStrictEqual(output, {});
 });

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/get-translations/file-extension-is-yaml.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/get-translations/file-extension-is-yaml.test.ts
@@ -21,11 +21,11 @@ test('lib | utils | translation-reducer | get-translations > file extension is .
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
-  let output = getTranslations(join(inputPath, 'en-us.yaml'));
+  let output = getTranslations(join(translationsDir, 'en-us.yaml'));
 
   assert.deepStrictEqual(output, {
     nested: {
@@ -34,7 +34,7 @@ test('lib | utils | translation-reducer | get-translations > file extension is .
     'no-arguments': 'Hello world!',
   });
 
-  output = getTranslations(join(inputPath, 'es.yaml'));
+  output = getTranslations(join(translationsDir, 'es.yaml'));
 
   assert.deepStrictEqual(output, {});
 });

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/get-translations/file-extension-is-yml.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/get-translations/file-extension-is-yml.test.ts
@@ -21,11 +21,11 @@ test('lib | utils | translation-reducer | get-translations > file extension is .
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
-  let output = getTranslations(join(inputPath, 'de-de.yml'));
+  let output = getTranslations(join(translationsDir, 'de-de.yml'));
 
   assert.deepStrictEqual(output, {
     nested: {
@@ -34,7 +34,7 @@ test('lib | utils | translation-reducer | get-translations > file extension is .
     'no-arguments': 'Hallo Welt!',
   });
 
-  output = getTranslations(join(inputPath, 'es.yml'));
+  output = getTranslations(join(translationsDir, 'es.yml'));
 
   assert.deepStrictEqual(output, {});
 });

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/get-translations/yaml-file-is-empty.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/get-translations/yaml-file-is-empty.test.ts
@@ -19,15 +19,15 @@ test('lib | utils | translation-reducer | get-translations > yaml file is empty'
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
-  let output = getTranslations(join(inputPath, 'en-us.yaml'));
+  let output = getTranslations(join(translationsDir, 'en-us.yaml'));
 
   assert.deepStrictEqual(output, {});
 
-  output = getTranslations(join(inputPath, 'es.yaml'));
+  output = getTranslations(join(translationsDir, 'es.yaml'));
 
   assert.deepStrictEqual(output, {});
 });

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/base-case-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/base-case-1.test.ts
@@ -18,7 +18,7 @@ test('lib | utils | translation-reducer | namespace-keys > base case (1)', funct
   const output = namespaceKeys(translations, {
     addonNames: [],
     filePath: join(projectRoot, 'translations/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {});

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/base-case-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/base-case-1.test.ts
@@ -11,14 +11,14 @@ test('lib | utils | translation-reducer | namespace-keys > base case (1)', funct
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
   const output = namespaceKeys(translations, {
     addonNames: [],
     filePath: join(projectRoot, 'translations/en-us.json'),
-    inputPath,
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {});

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/base-case-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/base-case-2.test.ts
@@ -27,7 +27,7 @@ test('lib | utils | translation-reducer | namespace-keys > base case (2)', funct
   const output = namespaceKeys(translations, {
     addonNames: [],
     filePath: join(projectRoot, 'translations/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/base-case-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/base-case-2.test.ts
@@ -20,14 +20,14 @@ test('lib | utils | translation-reducer | namespace-keys > base case (2)', funct
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
   const output = namespaceKeys(translations, {
     addonNames: [],
     filePath: join(projectRoot, 'translations/en-us.json'),
-    inputPath,
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/with-a-namespaced-addon-name-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/with-a-namespaced-addon-name-1.test.ts
@@ -11,14 +11,14 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
   let output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
-    filePath: join(inputPath, '__ember-intl-addon__/my-addon/en-us.json'),
-    inputPath,
+    filePath: join(translationsDir, '__ember-intl-addon__/my-addon/en-us.json'),
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {});
@@ -27,10 +27,10 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
   output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
     filePath: join(
-      inputPath,
+      translationsDir,
       '__ember-intl-addon__/my-addon/components/hello/en-us.json',
     ),
-    inputPath,
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -43,10 +43,10 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
   output = namespaceKeys(translations, {
     addonNames: ['@my-org/my-addon'],
     filePath: join(
-      inputPath,
+      translationsDir,
       '__ember-intl-addon__/@my-org/my-addon/en-us.json',
     ),
-    inputPath,
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {});

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/with-a-namespaced-addon-name-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/with-a-namespaced-addon-name-1.test.ts
@@ -18,7 +18,7 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
   let output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
     filePath: join(translationsDir, '__ember-intl-addon__/my-addon/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {});
@@ -30,7 +30,7 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
       translationsDir,
       '__ember-intl-addon__/my-addon/components/hello/en-us.json',
     ),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -46,7 +46,7 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
       translationsDir,
       '__ember-intl-addon__/@my-org/my-addon/en-us.json',
     ),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {});

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/with-a-namespaced-addon-name-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/with-a-namespaced-addon-name-2.test.ts
@@ -27,7 +27,7 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
   let output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
     filePath: join(translationsDir, '__ember-intl-addon__/my-addon/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -48,7 +48,7 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
       translationsDir,
       '__ember-intl-addon__/my-addon/components/hello/en-us.json',
     ),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -73,7 +73,7 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
       translationsDir,
       '__ember-intl-addon__/@my-org/my-addon/en-us.json',
     ),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/with-a-namespaced-addon-name-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/with-a-namespaced-addon-name-2.test.ts
@@ -20,14 +20,14 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
   let output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
-    filePath: join(inputPath, '__ember-intl-addon__/my-addon/en-us.json'),
-    inputPath,
+    filePath: join(translationsDir, '__ember-intl-addon__/my-addon/en-us.json'),
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -45,10 +45,10 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
   output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
     filePath: join(
-      inputPath,
+      translationsDir,
       '__ember-intl-addon__/my-addon/components/hello/en-us.json',
     ),
-    inputPath,
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -70,10 +70,10 @@ test('lib | utils | translation-reducer | namespace-keys > with a namespaced add
   output = namespaceKeys(translations, {
     addonNames: ['@my-org/my-addon'],
     filePath: join(
-      inputPath,
+      translationsDir,
       '__ember-intl-addon__/@my-org/my-addon/en-us.json',
     ),
-    inputPath,
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/without-a-namespaced-addon-name-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/without-a-namespaced-addon-name-1.test.ts
@@ -11,14 +11,14 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
   let output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
-    filePath: join(inputPath, 'my-addon/en-us.json'),
-    inputPath,
+    filePath: join(translationsDir, 'my-addon/en-us.json'),
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -28,8 +28,8 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   // Check nested translations
   output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
-    filePath: join(inputPath, 'my-addon/components/hello/en-us.json'),
-    inputPath,
+    filePath: join(translationsDir, 'my-addon/components/hello/en-us.json'),
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -43,8 +43,8 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   // Check scoped packages
   output = namespaceKeys(translations, {
     addonNames: ['@my-org/my-addon'],
-    filePath: join(inputPath, '@my-org/my-addon/en-us.json'),
-    inputPath,
+    filePath: join(translationsDir, '@my-org/my-addon/en-us.json'),
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/without-a-namespaced-addon-name-1.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/without-a-namespaced-addon-name-1.test.ts
@@ -18,7 +18,7 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   let output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
     filePath: join(translationsDir, 'my-addon/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -29,7 +29,7 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
     filePath: join(translationsDir, 'my-addon/components/hello/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -44,7 +44,7 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   output = namespaceKeys(translations, {
     addonNames: ['@my-org/my-addon'],
     filePath: join(translationsDir, '@my-org/my-addon/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/without-a-namespaced-addon-name-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/without-a-namespaced-addon-name-2.test.ts
@@ -20,14 +20,14 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   };
 
   const projectRoot = 'tmp/my-app';
-  const inputPath = join(projectRoot, 'translations');
+  const translationsDir = join(projectRoot, 'translations');
 
   loadFixture(inputProject, { projectRoot });
 
   let output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
-    filePath: join(inputPath, 'my-addon/en-us.json'),
-    inputPath,
+    filePath: join(translationsDir, 'my-addon/en-us.json'),
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -46,8 +46,8 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   // Check nested translations
   output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
-    filePath: join(inputPath, 'my-addon/components/hello/en-us.json'),
-    inputPath,
+    filePath: join(translationsDir, 'my-addon/components/hello/en-us.json'),
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -70,8 +70,8 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   // Check scoped packages
   output = namespaceKeys(translations, {
     addonNames: ['@my-org/my-addon'],
-    filePath: join(inputPath, '@my-org/my-addon/en-us.json'),
-    inputPath,
+    filePath: join(translationsDir, '@my-org/my-addon/en-us.json'),
+    inputPath: translationsDir,
   });
 
   assert.deepStrictEqual(output, {

--- a/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/without-a-namespaced-addon-name-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/utils/translation-reducer/namespace-keys/without-a-namespaced-addon-name-2.test.ts
@@ -27,7 +27,7 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   let output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
     filePath: join(translationsDir, 'my-addon/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -47,7 +47,7 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   output = namespaceKeys(translations, {
     addonNames: ['my-addon'],
     filePath: join(translationsDir, 'my-addon/components/hello/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {
@@ -71,7 +71,7 @@ test('lib | utils | translation-reducer | namespace-keys > without a namespaced 
   output = namespaceKeys(translations, {
     addonNames: ['@my-org/my-addon'],
     filePath: join(translationsDir, '@my-org/my-addon/en-us.json'),
-    inputPath: translationsDir,
+    translationsDir,
   });
 
   assert.deepStrictEqual(output, {


### PR DESCRIPTION
## Why?

Prepares for releasing `ember-intl@v9`.

For clarity, the `buildOptions` keys `inputPath` and `wrapTranslationsWithNamespace` will be renamed to `translationsDir` and `namespaceKeysByDir`, respectively. ~Meanwhile, `publicOnly` (only relevant to `@ember-intl/v1-compat`) will become internal and derived from `translationsDir` (is equal to `false` if and only if `translationsDir` is `'translations'`).~

~As a result, end-developers will only need to consider at most 3 build options (instead of 4 in `ember-intl@v8`).~

Update: `publicOnly` (only relevant to `@ember-intl/v1-compat`) will be renamed to `bundleSeparately`.


## Solution?

As proof of concept, I had allowed `@ember-intl/v1-compat` to accept two additional keys, `namespaceKeysByDir` and `translationsDir`, and map the old keys to new ones accordingly. End-developers will see a console log if they have `inputPath`, `publicOnly`, or `wrapTranslationsWithNamespace` in `config/ember-intl.js`.

Note, the name `inputPath` had likely come from an internal property in classic Ember called `inputPaths`. The changes to the tests in this pull request shows, the name `translationsDir` or `projectRoot` better documents intent.
