### PR TITLE
Deprecated test helper t

### DIFF
--- a/.changeset/huge-baboons-itch.md
+++ b/.changeset/huge-baboons-itch.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": minor
+"test-app-for-ember-intl": patch
+---
+
+Deprecated test helper t

--- a/packages/ember-intl/src/test-support/t.ts
+++ b/packages/ember-intl/src/test-support/t.ts
@@ -1,3 +1,4 @@
+import { deprecate } from '@ember/debug';
 import { getContext, type TestContext } from '@ember/test-helpers';
 
 import type { IntlService } from '../index.ts';
@@ -7,12 +8,28 @@ type TParameters = Parameters<IntlService['t']>;
 /**
  * Invokes the `t` method of the `intl` service.
  *
+ * @deprecated
  * @function t
  * @param {string} key
  * @param {object} [options]
  * @return {string}
  */
 export function t(key: TParameters[0], options?: TParameters[1]): string {
+  deprecate(
+    'The test helper t will be removed to encourage writing strong assertions. If possible, load translations in tests and always pass the string that you expect to see to hasText and includesText.',
+    false,
+    {
+      for: 'ember-intl',
+      id: 'ember-intl.remove-t-test-helper',
+      since: {
+        available: '8.4.0',
+        enabled: '8.4.0',
+      },
+      until: '9.0.0',
+      url: 'https://ember-intl.github.io/ember-intl/docs/test-helpers/t#alternatives',
+    },
+  );
+
   const { owner } = getContext() as TestContext;
 
   const intl = owner.lookup('service:intl');

--- a/tests/ember-intl/tests/integration/components/lazy-hello-test.gts
+++ b/tests/ember-intl/tests/integration/components/lazy-hello-test.gts
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { getDeprecations, render } from '@ember/test-helpers';
 import { addTranslations, setupIntl, t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import LazyHello from 'test-app-for-ember-intl/components/lazy-hello';
@@ -30,6 +30,16 @@ module('Integration | Component | lazy-hello', function (hooks) {
           t('lazy-hello.message', { name: 'Zoey' }),
           'We can write assertions against the test helper t().',
         );
+
+      const deprecationMessages = getDeprecations().map(
+        ({ message }) => message,
+      );
+
+      assert.true(
+        deprecationMessages.includes(
+          'The test helper t will be removed to encourage writing strong assertions. If possible, load translations in tests and always pass the string that you expect to see to hasText and includesText.',
+        ),
+      );
     });
 
     test('Translations are loaded after the component is rendered', async function (assert) {


### PR DESCRIPTION
## Why?

Prepares for releasing `ember-intl@v9`.

For a while, the [documentation site](https://ember-intl.github.io/ember-intl/docs/test-helpers/t) has recommended not using the test helper `t` and has provided alternatives:

> In general, _don't_ use the test helper `t`, because it creates a tautology: `t(...)` is equal to `t(...)` (here, the `t` refers to that from the `intl` service).
>
> An `hasText` or `includesText` assertion, when combined with the test helper `t`, becomes weak: It only guarantees that the translation key is correct, not the rendered message.
>
> [!NOTE]
> 
> Even when a translation is missing (by accident), the `hasText` or `includesText` assertion will pass, since the test helper `t` can't help you verify the rendered message.
>
> If possible, [load translations in tests](https://ember-intl.github.io/ember-intl/docs/test-helpers/add-translations#alternatives) and always pass the string that you expect to see to `hasText` and `includesText`. This way, you can easily know what the app displayed at a given time (static code analysis). You can also change translations with more confidence when assertions begin to fail.
>
> ```gts [tests/integration/components/hello-test.gts]{8}
> module('Integration | Component | hello', function (hooks) {
>   setupRenderingTest(hooks);
>   setupIntl(hooks, 'de-de');
> 
>   test('it renders', async function (assert) {
>     await render(<template><Hello @name="Zoey" /></template>);
> 
>     assert.dom('[data-test-message]').hasText('Hallo, Zoey!');
>   });
> });
> ```
> 
> [!TIP]
> 
> If assertions fail in multiple test files after changing a translation, then treat this as a sign that your tests didn't separate concerns well (i.e. tests don't trust one another). It's also possible that you need a test helper that hides how assertions are implemented.
> 
> Don't use the possible domino effect as a reason for using the test helper `t`.


## Solution?

Called `deprecate` from `@ember/debug` so that end-developers may become aware and remove the usage now. If they really want to keep weak assertions around, they may create and use a custom test helper.
