### PR TITLE
Marked @ember-intl/update as stable

### DIFF
--- a/.changeset/bright-points-drive.md
+++ b/.changeset/bright-points-drive.md
@@ -1,0 +1,5 @@
+---
+"@ember-intl/update": minor
+---
+
+Updated latestVersions

--- a/.changeset/some-peaches-play.md
+++ b/.changeset/some-peaches-play.md
@@ -1,0 +1,5 @@
+---
+"@ember-intl/update": major
+---
+
+Marked stable release

--- a/packages/ember-intl-update/src/steps/update-package/to-v8/update-package-json.ts
+++ b/packages/ember-intl-update/src/steps/update-package/to-v8/update-package-json.ts
@@ -12,10 +12,10 @@ import {
 import type { Options, Todos } from '../../../types/index.js';
 
 const latestVersions = {
-  '@ember-intl/lint': '^1.1.3',
-  '@ember-intl/v1-compat': '^1.1.0',
-  '@ember-intl/vite': '^1.0.1',
-  'ember-intl': '^8.2.5',
+  '@ember-intl/lint': '^1.5.0',
+  '@ember-intl/v1-compat': '^1.3.0',
+  '@ember-intl/vite': '^1.3.0',
+  'ember-intl': '^8.4.0',
 } as const;
 
 function updateDependencies(packageJson: PackageJson, options: Options): void {

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-addon/input/addon/components/example-format-time-allow-empty.hbs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-addon/input/addon/components/example-format-time-allow-empty.hbs
@@ -1,0 +1,1 @@
+{{format-time @message.timestamp allowEmpty=true}}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-addon/input/addon/components/example-intl-get-translation.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-addon/input/addon/components/example-intl-get-translation.js
@@ -1,0 +1,12 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class ExampleIntlGetTranslation extends Component {
+  @service intl;
+
+  get supportsName() {
+    const message = this.intl.lookup('hello.message');
+
+    return message.includes('{name}');
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-addon/input/addon/components/example-t-resilient.hbs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-addon/input/addon/components/example-t-resilient.hbs
@@ -1,0 +1,4 @@
+{{t
+  (concat "message.status-" @message.status)
+  resilient=true
+}}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-addon/input/addon/models/example-format-time-allow-empty.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-addon/input/addon/models/example-format-time-allow-empty.js
@@ -1,0 +1,16 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ExampleFormatTimeAllowEmpty extends Model {
+  @service intl;
+
+  @attr message;
+
+  get sendTime() {
+    const { message } = this;
+
+    return this.intl.formatTime(message?.timestamp, {
+      allowEmpty: true,
+    });
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-addon/output/addon/components/example-format-time-allow-empty.hbs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-addon/output/addon/components/example-format-time-allow-empty.hbs
@@ -1,0 +1,1 @@
+{{format-time @message.timestamp allowEmpty=true}}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-addon/output/addon/components/example-intl-get-translation.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-addon/output/addon/components/example-intl-get-translation.js
@@ -1,0 +1,12 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class ExampleIntlGetTranslation extends Component {
+  @service intl;
+
+  get supportsName() {
+    const message = this.intl.lookup('hello.message');
+
+    return message.includes('{name}');
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-addon/output/addon/components/example-t-resilient.hbs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-addon/output/addon/components/example-t-resilient.hbs
@@ -1,0 +1,4 @@
+{{t
+  (concat "message.status-" @message.status)
+  resilient=true
+}}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-addon/output/addon/models/example-format-time-allow-empty.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-addon/output/addon/models/example-format-time-allow-empty.js
@@ -1,0 +1,16 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ExampleFormatTimeAllowEmpty extends Model {
+  @service intl;
+
+  @attr message;
+
+  get sendTime() {
+    const { message } = this;
+
+    return this.intl.formatTime(message?.timestamp, {
+      allowEmpty: true,
+    });
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/components/example-format-date-allow-empty.hbs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/components/example-format-date-allow-empty.hbs
@@ -1,0 +1,1 @@
+{{format-date @message.timestamp allowEmpty=true}}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/components/example-t-default.hbs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/components/example-t-default.hbs
@@ -1,0 +1,4 @@
+{{t
+  (concat "message.status-" @message.status)
+  default="message.status-unknown"
+}}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/controllers/example-intl-translations-for.ts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/controllers/example-intl-translations-for.ts
@@ -1,0 +1,16 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import {
+  inject as service,
+  type Registry as Services,
+} from '@ember/service';
+
+export default class ExampleIntlTranslationsFor extends Controller {
+  @service declare intl: Services['intl'];
+
+  @action loadTranslations(): void {
+    if (!this.intl.translationsFor('de-de')) {
+      // Load translations
+    }
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/models/example-format-date-allow-empty.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/models/example-format-date-allow-empty.js
@@ -1,0 +1,16 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ExampleFormatDateAllowEmpty extends Model {
+  @service intl;
+
+  @attr message;
+
+  get sendDate() {
+    const { message } = this;
+
+    return this.intl.formatDate(message?.timestamp, {
+      allowEmpty: true,
+    });
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/models/example-t-default.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/models/example-t-default.js
@@ -1,0 +1,20 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ExampleTDefault extends Model {
+  @service intl;
+
+  @attr message;
+
+  get status() {
+    const { message } = this;
+
+    if (!message) {
+      return;
+    }
+
+    return this.intl.t(message.status, {
+      default: 'message.status-unknown',
+    });
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/models/example-t-resilient.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/models/example-t-resilient.js
@@ -1,0 +1,20 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ExampleTResilient extends Model {
+  @service intl;
+
+  @attr message;
+
+  get status() {
+    const { message } = this;
+
+    if (!message) {
+      return;
+    }
+
+    return this.intl.t(message.status, {
+      resilient: true,
+    });
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/routes/application.ts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/app/routes/application.ts
@@ -1,0 +1,31 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import type { IntlService } from 'ember-intl';
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: IntlService;
+
+  async beforeModel(): Promise<void> {
+    await this.setupIntl();
+  }
+
+  private async loadTranslations(locale: 'de-de' | 'en-us'): Promise<void> {
+    const { default: file } = (await import(
+      `/translations/${locale}.json`
+    )) as {
+      default: string;
+    };
+    const translations = JSON.parse(file) as Record<string, string>;
+
+    this.intl.addTranslations(locale, translations);
+  }
+
+  private async setupIntl(): Promise<void> {
+    await Promise.allSettled([
+      this.loadTranslations('de-de'),
+      this.loadTranslations('en-us'),
+    ]);
+
+    this.intl.locale = ['de-de'];
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/config/ember-intl.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/input/config/ember-intl.js
@@ -36,7 +36,7 @@ module.exports = function (/* environment */) {
      * @type {Boolean}
      * @default "false"
      */
-    publicOnly: false,
+    publicOnly: true,
 
     /**
      * Add the subdirectories of the translations as a namespace for all keys.

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/components/example-format-date-allow-empty.hbs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/components/example-format-date-allow-empty.hbs
@@ -1,0 +1,1 @@
+{{format-date @message.timestamp allowEmpty=true}}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/components/example-t-default.hbs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/components/example-t-default.hbs
@@ -1,0 +1,4 @@
+{{t
+  (concat "message.status-" @message.status)
+  default="message.status-unknown"
+}}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/controllers/example-intl-translations-for.ts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/controllers/example-intl-translations-for.ts
@@ -1,0 +1,16 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import {
+  inject as service,
+  type Registry as Services,
+} from '@ember/service';
+
+export default class ExampleIntlTranslationsFor extends Controller {
+  @service declare intl: Services['intl'];
+
+  @action loadTranslations(): void {
+    if (!this.intl.translationsFor('de-de')) {
+      // Load translations
+    }
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/models/example-format-date-allow-empty.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/models/example-format-date-allow-empty.js
@@ -1,0 +1,16 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ExampleFormatDateAllowEmpty extends Model {
+  @service intl;
+
+  @attr message;
+
+  get sendDate() {
+    const { message } = this;
+
+    return this.intl.formatDate(message?.timestamp, {
+      allowEmpty: true,
+    });
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/models/example-t-default.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/models/example-t-default.js
@@ -1,0 +1,20 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ExampleTDefault extends Model {
+  @service intl;
+
+  @attr message;
+
+  get status() {
+    const { message } = this;
+
+    if (!message) {
+      return;
+    }
+
+    return this.intl.t(message.status, {
+      default: 'message.status-unknown',
+    });
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/models/example-t-resilient.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/models/example-t-resilient.js
@@ -1,0 +1,20 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ExampleTResilient extends Model {
+  @service intl;
+
+  @attr message;
+
+  get status() {
+    const { message } = this;
+
+    if (!message) {
+      return;
+    }
+
+    return this.intl.t(message.status, {
+      resilient: true,
+    });
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/routes/application.ts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/app/routes/application.ts
@@ -1,0 +1,31 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import type { IntlService } from 'ember-intl';
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: IntlService;
+
+  async beforeModel(): Promise<void> {
+    await this.setupIntl();
+  }
+
+  private async loadTranslations(locale: 'de-de' | 'en-us'): Promise<void> {
+    const { default: file } = (await import(
+      `/translations/${locale}.json`
+    )) as {
+      default: string;
+    };
+    const translations = JSON.parse(file) as Record<string, string>;
+
+    this.intl.addTranslations(locale, translations);
+  }
+
+  private async setupIntl(): Promise<void> {
+    await Promise.allSettled([
+      this.loadTranslations('de-de'),
+      this.loadTranslations('en-us'),
+    ]);
+
+    this.intl.locale = ['de-de'];
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/config/ember-intl.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v1-app/output/config/ember-intl.js
@@ -36,7 +36,7 @@ module.exports = function (/* environment */) {
      * @type {Boolean}
      * @default "false"
      */
-    publicOnly: false,
+    publicOnly: true,
 
     /**
      * Add the subdirectories of the translations as a namespace for all keys.

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-addon/input/src/components/example-format-time-allow-empty.gjs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-addon/input/src/components/example-format-time-allow-empty.gjs
@@ -1,0 +1,7 @@
+import { formatTime } from 'ember-intl';
+
+const ExampleFormatTimeAllowEmpty = <template>
+  {{formatTime @message.timestamp allowEmpty=true}}
+</template>
+
+export default ExampleFormatTimeAllowEmpty;

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-addon/input/src/components/example-t-resilient.gts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-addon/input/src/components/example-t-resilient.gts
@@ -1,0 +1,21 @@
+import type { TOC } from '@ember/components/template-only';
+import { concat } from '@ember/helper';
+import { t } from 'ember-intl';
+
+interface ExampleTResilientSignature {
+  Args: {
+    message?: {
+      status: string;
+      timestamp: string;
+    };
+  };
+}
+
+const ExampleTResilient: TOC<ExampleTResilientSignature> = <template>
+  {{t
+    (concat "message.status-" @message.status)
+    resilient=true
+  }}
+</template>
+
+export default ExampleTResilient;

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-addon/output/src/components/example-format-time-allow-empty.gjs
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-addon/output/src/components/example-format-time-allow-empty.gjs
@@ -1,0 +1,7 @@
+import { formatTime } from 'ember-intl';
+
+const ExampleFormatTimeAllowEmpty = <template>
+  {{formatTime @message.timestamp allowEmpty=true}}
+</template>
+
+export default ExampleFormatTimeAllowEmpty;

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-addon/output/src/components/example-t-resilient.gts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-addon/output/src/components/example-t-resilient.gts
@@ -1,0 +1,21 @@
+import type { TOC } from '@ember/components/template-only';
+import { concat } from '@ember/helper';
+import { t } from 'ember-intl';
+
+interface ExampleTResilientSignature {
+  Args: {
+    message?: {
+      status: string;
+      timestamp: string;
+    };
+  };
+}
+
+const ExampleTResilient: TOC<ExampleTResilientSignature> = <template>
+  {{t
+    (concat "message.status-" @message.status)
+    resilient=true
+  }}
+</template>
+
+export default ExampleTResilient;

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-app/input/app/components/example-format-date-allow-empty.gts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-app/input/app/components/example-format-date-allow-empty.gts
@@ -1,0 +1,17 @@
+import type { TOC } from '@ember/components/template-only';
+import { formatDate } from 'ember-intl';
+
+interface ExampleFormatDateAllowEmptySignature {
+  Args: {
+    message?: {
+      status: string;
+      timestamp: string;
+    };
+  };
+}
+
+const ExampleFormatDateAllowEmpty: TOC<ExampleFormatDateAllowEmptySignature> = <template>
+  {{formatDate @message.timestamp allowEmpty=true}}
+</template>
+
+export default ExampleFormatDateAllowEmpty;

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-app/input/app/components/example-t-default.gts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-app/input/app/components/example-t-default.gts
@@ -1,0 +1,21 @@
+import type { TOC } from '@ember/components/template-only';
+import { concat } from '@ember/helper';
+import { t } from 'ember-intl';
+
+interface ExampleTDefaultSignature {
+  Args: {
+    message?: {
+      status: string;
+      timestamp: string;
+    };
+  };
+}
+
+const ExampleTDefault: TOC<ExampleTDefaultSignature> = <template>
+  {{t
+    (concat "message.status-" @message.status)
+    default="message.status-unknown"
+  }}
+</template>
+
+export default ExampleTDefault;

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-app/input/app/routes/application.ts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-app/input/app/routes/application.ts
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { type Registry as Services, service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: Services['intl'];
+
+  beforeModel(): void {
+    this.setupIntl();
+  }
+
+  private setupIntl(): void {
+    this.intl.locale = 'en-us';
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-app/input/config/ember-intl.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-app/input/config/ember-intl.js
@@ -3,7 +3,7 @@ module.exports = function () {
     errorOnNamedArgumentMismatch: true,
     errorOnMissingTranslations: true,
     fallbackLocale: 'en-us',
-    publicOnly: true,
+    publicOnly: false,
     wrapTranslationsWithNamespace: false,
   };
 };

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-app/output/app/components/example-format-date-allow-empty.gts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-app/output/app/components/example-format-date-allow-empty.gts
@@ -1,0 +1,17 @@
+import type { TOC } from '@ember/components/template-only';
+import { formatDate } from 'ember-intl';
+
+interface ExampleFormatDateAllowEmptySignature {
+  Args: {
+    message?: {
+      status: string;
+      timestamp: string;
+    };
+  };
+}
+
+const ExampleFormatDateAllowEmpty: TOC<ExampleFormatDateAllowEmptySignature> = <template>
+  {{formatDate @message.timestamp allowEmpty=true}}
+</template>
+
+export default ExampleFormatDateAllowEmpty;

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-app/output/app/components/example-t-default.gts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-app/output/app/components/example-t-default.gts
@@ -1,0 +1,21 @@
+import type { TOC } from '@ember/components/template-only';
+import { concat } from '@ember/helper';
+import { t } from 'ember-intl';
+
+interface ExampleTDefaultSignature {
+  Args: {
+    message?: {
+      status: string;
+      timestamp: string;
+    };
+  };
+}
+
+const ExampleTDefault: TOC<ExampleTDefaultSignature> = <template>
+  {{t
+    (concat "message.status-" @message.status)
+    default="message.status-unknown"
+  }}
+</template>
+
+export default ExampleTDefault;

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-app/output/app/routes/application.ts
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-app/output/app/routes/application.ts
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { type Registry as Services, service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: Services['intl'];
+
+  beforeModel(): void {
+    this.setupIntl();
+  }
+
+  private setupIntl(): void {
+    this.intl.locale = 'en-us';
+  }
+}

--- a/packages/ember-intl-update/tests/fixtures/v6-v2-app/output/config/ember-intl.js
+++ b/packages/ember-intl-update/tests/fixtures/v6-v2-app/output/config/ember-intl.js
@@ -3,7 +3,7 @@ module.exports = function () {
     errorOnNamedArgumentMismatch: true,
     errorOnMissingTranslations: true,
     fallbackLocale: 'en-us',
-    publicOnly: true,
+    publicOnly: false,
     wrapTranslationsWithNamespace: false,
   };
 };

--- a/packages/ember-intl-update/tests/fixtures/v7-v1-addon/output/package.json
+++ b/packages/ember-intl-update/tests/fixtures/v7-v1-addon/output/package.json
@@ -5,11 +5,11 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-intl": "^8.2.5"
+    "ember-intl": "^8.4.0"
   },
   "devDependencies": {
-    "@ember-intl/lint": "^1.1.3",
-    "@ember-intl/v1-compat": "^1.1.0",
+    "@ember-intl/lint": "^1.5.0",
+    "@ember-intl/v1-compat": "^1.3.0",
     "ember-source": "~6.8.0"
   },
   "ember": {

--- a/packages/ember-intl-update/tests/fixtures/v7-v1-app/output/package.json
+++ b/packages/ember-intl-update/tests/fixtures/v7-v1-app/output/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "@ember-intl/lint": "^1.1.3",
-    "@ember-intl/v1-compat": "^1.1.0",
+    "@ember-intl/lint": "^1.5.0",
+    "@ember-intl/v1-compat": "^1.3.0",
     "@embroider/webpack": "^4.1.2",
-    "ember-intl": "^8.2.5",
+    "ember-intl": "^8.4.0",
     "ember-source": "~6.8.0"
   },
   "ember": {

--- a/packages/ember-intl-update/tests/fixtures/v7-v2-addon/output/package.json
+++ b/packages/ember-intl-update/tests/fixtures/v7-v2-addon/output/package.json
@@ -11,8 +11,8 @@
     "translations"
   ],
   "devDependencies": {
-    "@ember-intl/lint": "^1.1.3",
-    "ember-intl": "^8.2.5",
+    "@ember-intl/lint": "^1.5.0",
+    "ember-intl": "^8.4.0",
     "ember-source": "~6.8.0"
   },
   "ember": {

--- a/packages/ember-intl-update/tests/fixtures/v7-v2-app/output/package.json
+++ b/packages/ember-intl-update/tests/fixtures/v7-v2-app/output/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "@ember-intl/lint": "^1.1.3",
-    "@ember-intl/vite": "^1.0.1",
+    "@ember-intl/lint": "^1.5.0",
+    "@ember-intl/vite": "^1.3.0",
     "@embroider/vite": "^1.4.3",
-    "ember-intl": "^8.2.5",
+    "ember-intl": "^8.4.0",
     "ember-source": "~6.8.0"
   },
   "ember": {


### PR DESCRIPTION
## Why?

Prepares for releasing `ember-intl@v9`.

`@ember-intl/update` currently provides little support for updating `ember-intl` from `v6` to `v7`. I went ahead with adding some fixtures, but may be unable to work on implementation any time soon.
