### PR TITLE
Dropped support for @ember/test-helpers@v4

### DIFF
--- a/.changeset/green-animals-walk.md
+++ b/.changeset/green-animals-walk.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": major
+---
+
+Dropped support for `@ember/test-helpers@v4`

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -81,7 +81,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^4.0.0 || ^5.0.0"
+    "@ember/test-helpers": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@ember/test-helpers": {


### PR DESCRIPTION
## Why?

The last `4.x` release had occurred on January 30, 2025.


## References

- https://github.com/emberjs/ember-test-helpers/blob/v5.4.3/CHANGELOG.md
