### PR TITLE
Allowed @ember-intl/lint to support the syntax @service()

### DIFF
--- a/.changeset/sparkly-roses-attend.md
+++ b/.changeset/sparkly-roses-attend.md
@@ -1,0 +1,5 @@
+---
+"@ember-intl/lint": patch
+---
+
+Supported the syntax `@service()`

--- a/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
@@ -43,7 +43,20 @@ export function findDependencies(file: string): Dependencies {
             return false;
           }
 
-          const param = decorator.expression.arguments[0]!;
+          const param = decorator.expression.arguments[0];
+
+          if (param === undefined) {
+            if (
+              path.node.key.type !== 'Identifier' ||
+              path.node.key.name !== 'intl'
+            ) {
+              return false;
+            }
+
+            dependencies.services.intl = path.node.key.name;
+
+            return false;
+          }
 
           if (param.type !== 'StringLiteral' || param.value !== 'intl') {
             return false;

--- a/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
@@ -38,7 +38,8 @@ export function findDependencies(file: string): Dependencies {
         case 'CallExpression': {
           if (
             decorator.expression.callee.type !== 'Identifier' ||
-            decorator.expression.callee.name !== 'service'
+            decorator.expression.callee.name !== 'service' ||
+            path.node.key.type !== 'Identifier'
           ) {
             return false;
           }
@@ -46,41 +47,31 @@ export function findDependencies(file: string): Dependencies {
           const param = decorator.expression.arguments[0];
 
           if (param === undefined) {
-            if (
-              path.node.key.type !== 'Identifier' ||
-              path.node.key.name !== 'intl'
-            ) {
-              return false;
+            if (path.node.key.name === 'intl') {
+              dependencies.services.intl = path.node.key.name;
             }
 
+            return false;
+          }
+
+          if (param.type === 'StringLiteral' && param.value === 'intl') {
             dependencies.services.intl = path.node.key.name;
-
-            return false;
           }
-
-          if (param.type !== 'StringLiteral' || param.value !== 'intl') {
-            return false;
-          }
-
-          // @ts-expect-error: Incorrect type
-          dependencies.services.intl = path.node.key.name as string;
 
           break;
         }
 
         case 'Identifier': {
-          if (decorator.expression.name !== 'service') {
-            return false;
-          }
-
           if (
-            path.node.key.type !== 'Identifier' ||
-            path.node.key.name !== 'intl'
+            decorator.expression.name !== 'service' ||
+            path.node.key.type !== 'Identifier'
           ) {
             return false;
           }
 
-          dependencies.services.intl = path.node.key.name;
+          if (path.node.key.name === 'intl') {
+            dependencies.services.intl = path.node.key.name;
+          }
 
           break;
         }

--- a/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/find-used-keys/shared/find-dependencies.ts
@@ -88,9 +88,12 @@ export function findDependencies(file: string): Dependencies {
       const importPath = path.node.source.value;
       const specifiers = path.node.specifiers;
 
+      if (specifiers === undefined) {
+        return false;
+      }
+
       switch (importPath) {
         case 'ember-intl': {
-          // @ts-expect-error: Incorrect type
           const t = specifiers.find((specifier) => {
             return (
               specifier.type === 'ImportSpecifier' &&
@@ -99,11 +102,9 @@ export function findDependencies(file: string): Dependencies {
           });
 
           if (t) {
-            // @ts-expect-error: Incorrect type
-            dependencies.helpers.t = t.local.name as string;
+            dependencies.helpers.t = t.local!.name as string;
           }
 
-          // @ts-expect-error: Incorrect type
           const tKey = specifiers.find((specifier) => {
             return (
               specifier.type === 'ImportSpecifier' &&
@@ -112,44 +113,37 @@ export function findDependencies(file: string): Dependencies {
           });
 
           if (tKey) {
-            // @ts-expect-error: Incorrect type
-            dependencies.helpers.tKey = tKey.local.name as string;
+            dependencies.helpers.tKey = tKey.local!.name as string;
           }
 
           break;
         }
 
         case 'ember-intl/helpers/t': {
-          // @ts-expect-error: Incorrect type
           const t = specifiers.find((specifier) => {
             return (
               specifier.type === 'ImportDefaultSpecifier' &&
-              // @ts-expect-error: Incorrect type
-              specifier.local.type === 'Identifier'
+              specifier.local!.type === 'Identifier'
             );
           });
 
           if (t) {
-            // @ts-expect-error: Incorrect type
-            dependencies.helpers.t = t.local.name as string;
+            dependencies.helpers.t = t.local!.name as string;
           }
 
           break;
         }
 
         case 'ember-intl/helpers/t-key': {
-          // @ts-expect-error: Incorrect type
           const tKey = specifiers.find((specifier) => {
             return (
               specifier.type === 'ImportDefaultSpecifier' &&
-              // @ts-expect-error: Incorrect type
-              specifier.local.type === 'Identifier'
+              specifier.local!.type === 'Identifier'
             );
           });
 
           if (tKey) {
-            // @ts-expect-error: Incorrect type
-            dependencies.helpers.tKey = tKey.local.name as string;
+            dependencies.helpers.tKey = tKey.local!.name as string;
           }
 
           break;

--- a/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-gjs/edge-case-2.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-gjs/edge-case-2.test.ts
@@ -2,7 +2,7 @@ import { assert, normalizeFile, test } from '@codemod-utils/tests';
 
 import { inGjsGts } from '../../../../../src/utils/analyze-project/find-used-keys/index.js';
 
-test('utils | analyze-project | find-used-keys | in-gjs > component (4)', function () {
+test('utils | analyze-project | find-used-keys | in-gjs > edge case (2)', function () {
   const file = normalizeFile([
     `import { service } from '@ember/service';`,
     `import Component from '@glimmer/component';`,

--- a/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-gjs/edge-case-3.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-gjs/edge-case-3.test.ts
@@ -1,0 +1,29 @@
+import { assert, normalizeFile, test } from '@codemod-utils/tests';
+
+import { inGjsGts } from '../../../../../src/utils/analyze-project/find-used-keys/index.js';
+
+test('utils | analyze-project | find-used-keys | in-gjs > edge case (3)', function () {
+  const file = normalizeFile([
+    `import { inject as service } from '@ember/service';`,
+    `import Component from '@glimmer/component';`,
+    ``,
+    `export default class Hello extends Component {`,
+    `  @service() intl;`,
+    ``,
+    `  get getter01() {`,
+    `    return this.intl.t('key01');`,
+    `  }`,
+    ``,
+    `  get getter03() {`,
+    `    return this.someCondition ? this.intl.t('key03') : this.intl.t('key04');`,
+    `  }`,
+    ``,
+    `  <template></template>`,
+    `}`,
+    ``,
+  ]);
+
+  const keys = inGjsGts(file);
+
+  assert.deepStrictEqual(keys, ['key01', 'key03', 'key04']);
+});

--- a/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-gts/edge-case-2.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-gts/edge-case-2.test.ts
@@ -2,7 +2,7 @@ import { assert, normalizeFile, test } from '@codemod-utils/tests';
 
 import { inGjsGts } from '../../../../../src/utils/analyze-project/find-used-keys/index.js';
 
-test('utils | analyze-project | find-used-keys | in-gts > component (4)', function () {
+test('utils | analyze-project | find-used-keys | in-gts > edge case (2)', function () {
   const file = normalizeFile([
     `import { type Registry as Services, service } from '@ember/service';`,
     `import Component from '@glimmer/component';`,

--- a/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-gts/edge-case-3.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-gts/edge-case-3.test.ts
@@ -1,0 +1,36 @@
+import { assert, normalizeFile, test } from '@codemod-utils/tests';
+
+import { inGjsGts } from '../../../../../src/utils/analyze-project/find-used-keys/index.js';
+
+test('utils | analyze-project | find-used-keys | in-gts > edge case (3)', function () {
+  const file = normalizeFile([
+    `import {`,
+    `  inject as service,`,
+    `  type Registry as Services,`,
+    `} from '@ember/service';`,
+    `import Component from '@glimmer/component';`,
+    ``,
+    `interface HelloSignature {`,
+    `  Args: {};`,
+    `}`,
+    ``,
+    `export default class Hello extends Component<HelloSignature> {`,
+    `  @service() declare intl: Services['intl'];`,
+    ``,
+    `  get getter01(): string {`,
+    `    return this.intl.t('key01');`,
+    `  }`,
+    ``,
+    `  get getter03(): string {`,
+    `    return this.someCondition ? this.intl.t('key03') : this.intl.t('key04');`,
+    `  }`,
+    ``,
+    `  <template></template>`,
+    `}`,
+    ``,
+  ]);
+
+  const keys = inGjsGts(file);
+
+  assert.deepStrictEqual(keys, ['key01', 'key03', 'key04']);
+});

--- a/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-js/edge-case-3.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-js/edge-case-3.test.ts
@@ -2,7 +2,7 @@ import { assert, normalizeFile, test } from '@codemod-utils/tests';
 
 import { inJsTs } from '../../../../../src/utils/analyze-project/find-used-keys/index.js';
 
-test('utils | analyze-project | find-used-keys | in-js > edge case (2)', function () {
+test('utils | analyze-project | find-used-keys | in-js > edge case (3)', function () {
   const file = normalizeFile([
     `import Component from '@glimmer/component';`,
     `import { tKey as t } from 'ember-intl';`,

--- a/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-ts/edge-case-3.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/find-used-keys/in-ts/edge-case-3.test.ts
@@ -2,7 +2,7 @@ import { assert, normalizeFile, test } from '@codemod-utils/tests';
 
 import { inJsTs } from '../../../../../src/utils/analyze-project/find-used-keys/index.js';
 
-test('utils | analyze-project | find-used-keys | in-ts > edge case (2)', function () {
+test('utils | analyze-project | find-used-keys | in-ts > edge case (3)', function () {
   const file = normalizeFile([
     `import Component from '@glimmer/component';`,
     `import { tKey as t } from 'ember-intl';`,


### PR DESCRIPTION
## Why?

Closes #2181. Allows `@ember-intl/lint` to support the syntax `@service()` without a string identifier as the first argument.

```js
class MyClass {
  @service() intl;
}
```

The syntax is (in my view) an edge case, but `ember-source@7.1.0` still supports it.


## Solution?

I fixed the bug after introducing unit tests. Then, I refactored code to improve readability and to remove ignore directives for TypeScript in the same source file.

Because the packages are in the phase of beta release, I will need to backport the bug fix to `@ember-intl/lint@v1`.
