### PR TITLE
Removed handling spaces in translation folder names

### DIFF
--- a/.changeset/real-views-live.md
+++ b/.changeset/real-views-live.md
@@ -1,0 +1,9 @@
+---
+"@ember-intl/v1-compat": major
+"@ember-intl/lint": major
+"@ember-intl/vite": major
+"test-ember-intl-v1-compat": minor
+"docs-app-for-ember-intl": minor
+---
+
+Removed handling spaces in translation folder names

--- a/docs/ember-intl/src/docs/migration/v9.md
+++ b/docs/ember-intl/src/docs/migration/v9.md
@@ -16,6 +16,13 @@ Projects with these versions are supported when issues arise.
 - `@ember/test-helpers` 5.x and above
 
 
+### Removed handling spaces in translation folder names {#removed-handling-spaces-in-translation-folder-names}
+
+Apps can use `wrapTranslationsWithNamespace` (now called `namespaceKeysByDir`) to namespace translation keys by folder names. From `5.x` to `7.x`, `ember-intl` used to convert spaces in folder names to underscores. This implementation detail was likely seldom needed and was unknown to end-developers.
+
+`@ember-intl/lint`, `@ember-intl/v1-compat`, and `@ember-intl/vite` will no longer normalize the folder names. If a subfolder in `/translations` has a space in its name, replace the space with the underscore `_` to keep your source code the same.
+
+
 ### Removed test helper `t` {#breaking-changes-removed-test-helper-t}
 
 For a while, the documentation site recommended not using the test helper `t` because it creates a tautology: `t(...)` is equal to `t(...)` (here, the `t` refers to that from the `intl` service).

--- a/packages/ember-intl-lint/src/utils/analyze-project/merge-translation-files/extract-translations.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/merge-translation-files/extract-translations.ts
@@ -29,7 +29,7 @@ function getPrefix(data: Data): string {
     return '';
   }
 
-  const prefix = relativePath.replaceAll(sep, '.').replaceAll(' ', '_');
+  const prefix = relativePath.replaceAll(sep, '.');
 
   return `${prefix}.`;
 }

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/edge-case-folder-name-has-space.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/edge-case-folder-name-has-space.test.ts
@@ -22,16 +22,16 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
   });
 
   assert.deepStrictEqual(translationObject, {
-    '__things_for__product_.card.learn-more.aria-label':
+    '  things for  product .card.learn-more.aria-label':
       'Learn more about {productName}',
-    '__things_for__product_.card.learn-more.label': 'Learn more',
-    '__things_for__product_.details.add-to-cart': 'Add to Cart',
-    '__things_for__product_.details.description': 'Description',
-    '__things_for__product_.details.price': 'Price',
-    '__things_for__product_.details.rating': 'Rating',
-    '__things_for__product_.details.rating-value':
+    '  things for  product .card.learn-more.label': 'Learn more',
+    '  things for  product .details.add-to-cart': 'Add to Cart',
+    '  things for  product .details.description': 'Description',
+    '  things for  product .details.price': 'Price',
+    '  things for  product .details.rating': 'Rating',
+    '  things for  product .details.rating-value':
       '{productRating} out of 5 stars',
-    '__things_for__product_.details.seller': 'Seller',
-    '__things_for__product_.title': '{productName}',
+    '  things for  product .details.seller': 'Seller',
+    '  things for  product .title': '{productName}',
   });
 });

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/edge-case-folder-name-has-space.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/edge-case-folder-name-has-space.test.ts
@@ -23,16 +23,16 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
   });
 
   assert.deepStrictEqual(translationObject, {
-    '__things_for__product_.card.learn-more.aria-label':
+    '  things for  product .card.learn-more.aria-label':
       'Learn more about {productName}',
-    '__things_for__product_.card.learn-more.label': 'Learn more',
-    '__things_for__product_.details.add-to-cart': 'Add to Cart',
-    '__things_for__product_.details.description': 'Description',
-    '__things_for__product_.details.price': 'Price',
-    '__things_for__product_.details.rating': 'Rating',
-    '__things_for__product_.details.rating-value':
+    '  things for  product .card.learn-more.label': 'Learn more',
+    '  things for  product .details.add-to-cart': 'Add to Cart',
+    '  things for  product .details.description': 'Description',
+    '  things for  product .details.price': 'Price',
+    '  things for  product .details.rating': 'Rating',
+    '  things for  product .details.rating-value':
       '{productRating} out of 5 stars',
-    '__things_for__product_.details.seller': 'Seller',
-    '__things_for__product_.title': '{productName}',
+    '  things for  product .details.seller': 'Seller',
+    '  things for  product .title': '{productName}',
   });
 });

--- a/packages/ember-intl-v1-compat/lib/utils/translation-reducer/namespace-keys.js
+++ b/packages/ember-intl-v1-compat/lib/utils/translation-reducer/namespace-keys.js
@@ -39,7 +39,7 @@ function namespaceKeys(translations, data) {
   if (folderNames.length > 0) {
     for (const folderName of folderNames) {
       translations = {
-        [folderName.replaceAll(' ', '_')]: translations,
+        [folderName]: translations,
       };
     }
   }

--- a/packages/ember-intl-vite/src/utils/analyze-project/merge-translation-files/extract-translations.ts
+++ b/packages/ember-intl-vite/src/utils/analyze-project/merge-translation-files/extract-translations.ts
@@ -29,7 +29,7 @@ function getPrefix(data: Data): string {
     return '';
   }
 
-  const prefix = relativePath.replaceAll(sep, '.').replaceAll(' ', '_');
+  const prefix = relativePath.replaceAll(sep, '.');
 
   return `${prefix}.`;
 }

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/edge-case-folder-name-has-space.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/edge-case-folder-name-has-space.test.ts
@@ -22,16 +22,16 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
   });
 
   assert.deepStrictEqual(translationObject, {
-    '__things_for__product_.card.learn-more.aria-label':
+    '  things for  product .card.learn-more.aria-label':
       'Learn more about {productName}',
-    '__things_for__product_.card.learn-more.label': 'Learn more',
-    '__things_for__product_.details.add-to-cart': 'Add to Cart',
-    '__things_for__product_.details.description': 'Description',
-    '__things_for__product_.details.price': 'Price',
-    '__things_for__product_.details.rating': 'Rating',
-    '__things_for__product_.details.rating-value':
+    '  things for  product .card.learn-more.label': 'Learn more',
+    '  things for  product .details.add-to-cart': 'Add to Cart',
+    '  things for  product .details.description': 'Description',
+    '  things for  product .details.price': 'Price',
+    '  things for  product .details.rating': 'Rating',
+    '  things for  product .details.rating-value':
       '{productRating} out of 5 stars',
-    '__things_for__product_.details.seller': 'Seller',
-    '__things_for__product_.title': '{productName}',
+    '  things for  product .details.seller': 'Seller',
+    '  things for  product .title': '{productName}',
   });
 });

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/edge-case-folder-name-has-space.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/edge-case-folder-name-has-space.test.ts
@@ -23,16 +23,16 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
   });
 
   assert.deepStrictEqual(translationObject, {
-    '__things_for__product_.card.learn-more.aria-label':
+    '  things for  product .card.learn-more.aria-label':
       'Learn more about {productName}',
-    '__things_for__product_.card.learn-more.label': 'Learn more',
-    '__things_for__product_.details.add-to-cart': 'Add to Cart',
-    '__things_for__product_.details.description': 'Description',
-    '__things_for__product_.details.price': 'Price',
-    '__things_for__product_.details.rating': 'Rating',
-    '__things_for__product_.details.rating-value':
+    '  things for  product .card.learn-more.label': 'Learn more',
+    '  things for  product .details.add-to-cart': 'Add to Cart',
+    '  things for  product .details.description': 'Description',
+    '  things for  product .details.price': 'Price',
+    '  things for  product .details.rating': 'Rating',
+    '  things for  product .details.rating-value':
       '{productRating} out of 5 stars',
-    '__things_for__product_.details.seller': 'Seller',
-    '__things_for__product_.title': '{productName}',
+    '  things for  product .details.seller': 'Seller',
+    '  things for  product .title': '{productName}',
   });
 });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/edge-case-folder-name-has-space.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/edge-case-folder-name-has-space.test.ts
@@ -39,7 +39,7 @@ test('lib | broccoli | translation-reducer | mergeTranslations > edge case (fold
 
   assert.deepStrictEqual(translations, {
     'en-us': {
-      __things_for__product_: {
+      '  things for  product ': {
         'card.learn-more.aria-label': 'Learn more about {productName}',
         'card.learn-more.label': 'Learn more',
         'details.add-to-cart': 'Add to Cart',


### PR DESCRIPTION
## Why?

From `5.x` to `7.x`, `ember-intl` used to convert spaces in folder names to underscores. This implementation detail was likely seldom needed and was unknown to end-developers. Even I had forgotten the detail and needed to patch the implementation of `@ember-intl/lint` and `@ember-intl/vite` in #2110.


## Solution?

I removed the `replaceAll(' ', '_')` calls from `@ember-intl/lint`, `@ember-intl/v1-compat`, and `@ember-intl/vite`.

If an end-developer has apps with `wrapTranslationsWithNamespace: true`, they will need to replace spaces in translation folder names with underscores if they want to keep their source code the same. Alternatively, they can rename the folders and change the source code accordingly.
