### PR TITLE
Removed handling nested translation JSON

### DIFF
--- a/.changeset/chatty-days-heal.md
+++ b/.changeset/chatty-days-heal.md
@@ -1,0 +1,24 @@
+---
+"@ember-intl/v1-compat": major
+"@ember-intl/lint": major
+"@ember-intl/vite": major
+"ember-intl": major
+"test-ember-intl-v1-compat": minor
+"test-app-for-ember-intl": minor
+"docs-app-for-ember-intl": minor
+"my-v1-addon": minor
+"my-v1-app": minor
+"my-v1-app-with-fallbacks": minor
+"my-v1-app-with-lazy-loaded-translations": minor
+"my-v1-app-with-namespace-from-folders": minor
+"my-v1-classic-app": minor
+"my-v1-classic-app-with-lazy-loaded-translations": minor
+"my-v1-engine": minor
+"my-v2-addon": minor
+"my-v2-app": minor
+"my-v2-app-with-fallbacks": minor
+"my-v2-app-with-lazy-loaded-translations": minor
+"my-v2-app-with-namespace-from-folders": minor
+---
+
+Removed handling nested translation JSON

--- a/docs/ember-intl/src/docs/migration/v9.md
+++ b/docs/ember-intl/src/docs/migration/v9.md
@@ -16,7 +16,57 @@ Projects with these versions are supported when issues arise.
 - `@ember/test-helpers` 5.x and above
 
 
-### Removed handling spaces in translation folder names {#removed-handling-spaces-in-translation-folder-names}
+### Removed handling nested translation JSON {#breaking-changes-removed-handling-nested-translation-json}
+
+From `5.x` to `7.x`, the `intl` service's `addTranslations` flattened a translation JSON (data representation of translation files), because the Node part of the addon, which was responsible for reading translation files, didn't handle flattening.
+
+In `8.x`, `addTranslations` continued to flatten a JSON even though `@ember-intl/vite` had already flattened it, because `@ember-intl/v1-compat` didn't handle flattening. That is, Vite apps encounter an unnecessary cost, while maintaining the `ember-intl` project is more difficult due to different implemenations and unclear boundaries.
+
+Going forward, all packages that load translations (i.e. `lint`, `v1-compat`, and `vite`) will be responsible for flattening a translation JSON. When you call `intl.addTranslations()`, you will need to ensure that `translations` (the 2nd parameter) is flat:
+
+```diff
+type TranslationKey = string;
+type TranslationMessage = string;
+
+- type TranslationJson = Record<TranslationJson | TranslationKey, TranslationMessage>;
++ type TranslationJson = Record<TranslationKey, TranslationMessage>;
+```
+
+```diff
+this.intl.addTranslations('en-us', {
+-   hello: {
+-     message: 'Hello, {name}!',
+-   },
++   'hello.message': 'Hello, {name}!',
+});
+```
+
+You will need to update code if your tests rely on the test helper `addTranslations` or on `setupIntl` with `translations` (the 3rd parameter used to stub translations).
+
+```diff
+import { setupIntl } from 'ember-intl/test-support';
+import Hello from 'my-app/components/hello';
+import { setupRenderingTest } from 'my-app/tests/helpers';
+import { module, test } from 'qunit';
+
+module('Integration | Component | hello', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us', {
+-   hello: {
+-     message: 'Hi, {name}!',
+-   },
++   'hello.message': 'Hi, {name}!',
+  });
+
+  test('it renders', async function (assert) {
+    // ...
+  });
+});
+```
+
+
+
+### Removed handling spaces in translation folder names {#breaking-changes-removed-handling-spaces-in-translation-folder-names}
 
 Apps can use `wrapTranslationsWithNamespace` (now called `namespaceKeysByDir`) to namespace translation keys by folder names. From `5.x` to `7.x`, `ember-intl` used to convert spaces in folder names to underscores. This implementation detail was likely seldom needed and was unknown to end-developers.
 

--- a/docs/ember-intl/src/docs/test-helpers/add-translations.md
+++ b/docs/ember-intl/src/docs/test-helpers/add-translations.md
@@ -9,9 +9,7 @@ type TranslationKey = string;
 
 type TranslationMessage = string;
 
-type TranslationJson = {
-  [key: TranslationKey]: TranslationJson | TranslationMessage;
-};
+type TranslationJson = Record<TranslationKey, TranslationMessage>;
 
 function addTranslations(
   locale: string,

--- a/docs/ember-intl/src/docs/test-helpers/setup-intl.md
+++ b/docs/ember-intl/src/docs/test-helpers/setup-intl.md
@@ -9,9 +9,7 @@ type TranslationKey = string;
 
 type TranslationMessage = string;
 
-type TranslationJson = {
-  [key: TranslationKey]: TranslationJson | TranslationMessage;
-};
+type TranslationJson = Record<TranslationKey, TranslationMessage>;
 
 function setupIntl(
   hooks: NestedHooks,

--- a/packages/ember-intl-lint/src/steps/analyze-project/merge-translation-files.ts
+++ b/packages/ember-intl-lint/src/steps/analyze-project/merge-translation-files.ts
@@ -24,7 +24,7 @@ export function mergeTranslationFiles(
   translationFiles.forEach((data, filePath) => {
     const file = readFileSync(join(projectRoot, filePath), 'utf8');
 
-    const translationObject = extractTranslations(file, {
+    const translationJson = extractTranslations(file, {
       filePath,
       namespaceKeysByDir: buildOptions.namespaceKeysByDir,
       translationsDir: data.translationsDir,
@@ -34,7 +34,7 @@ export function mergeTranslationFiles(
       translations.get(data.locale) ??
       new Map<TranslationKey, ProjectTranslationData>();
 
-    for (const [key, message] of Object.entries(translationObject)) {
+    for (const [key, message] of Object.entries(translationJson)) {
       keyToData.set(key, {
         filePath,
         message,

--- a/packages/ember-intl-lint/src/types/index.ts
+++ b/packages/ember-intl-lint/src/types/index.ts
@@ -66,15 +66,11 @@ type ProjectTranslationData = {
 
 type TranslationFilePath = string;
 
-type TranslationJson = {
-  [key: TranslationKey]: TranslationJson | TranslationMessage;
-};
+type TranslationJson = Record<TranslationKey, TranslationMessage>;
 
 type TranslationKey = string;
 
 type TranslationMessage = string;
-
-type TranslationObject = Record<TranslationKey, TranslationMessage>;
 
 type UserConfig = Partial<{
   addonPaths: string[];
@@ -99,6 +95,5 @@ export type {
   TranslationJson,
   TranslationKey,
   TranslationMessage,
-  TranslationObject,
   UserConfig,
 };

--- a/packages/ember-intl-lint/src/utils/analyze-project/merge-translation-files/extract-translations.ts
+++ b/packages/ember-intl-lint/src/utils/analyze-project/merge-translation-files/extract-translations.ts
@@ -8,13 +8,16 @@ import type {
   TranslationJson,
   TranslationKey,
   TranslationMessage,
-  TranslationObject,
 } from '../../../types/index.js';
 
 type Data = {
   filePath: TranslationFilePath;
   namespaceKeysByDir: boolean;
   translationsDir: string;
+};
+
+type TranslationJsonRaw = {
+  [key: TranslationKey]: TranslationJsonRaw | TranslationMessage;
 };
 
 function getPrefix(data: Data): string {
@@ -35,18 +38,18 @@ function getPrefix(data: Data): string {
 }
 
 function traverse(
-  translationJson: TranslationJson,
+  json: TranslationJsonRaw,
   data: {
     callback: (key: TranslationKey, message: TranslationMessage) => void;
     prefix: string;
   },
 ): void {
-  for (const key in translationJson) {
-    if (!Object.hasOwn(translationJson, key)) {
+  for (const key in json) {
+    if (!Object.hasOwn(json, key)) {
       continue;
     }
 
-    const value = translationJson[key]!;
+    const value = json[key]!;
 
     if (typeof value === 'object') {
       traverse(value, {
@@ -61,29 +64,26 @@ function traverse(
   }
 }
 
-export function extractTranslations(
-  file: string,
-  data: Data,
-): TranslationObject {
-  const translationObject: TranslationObject = {};
+export function extractTranslations(file: string, data: Data): TranslationJson {
+  const translationJson: TranslationJson = {};
 
   if (file === '') {
-    return translationObject;
+    return translationJson;
   }
 
   const { ext } = parseFilePath(data.filePath);
 
   try {
-    const translationJson =
+    const json =
       ext === '.json'
-        ? (JSON.parse(file) as TranslationJson)
-        : (load(file) as TranslationJson);
+        ? (JSON.parse(file) as TranslationJsonRaw)
+        : (load(file) as TranslationJsonRaw);
 
     const prefix = getPrefix(data);
 
-    traverse(translationJson, {
+    traverse(json, {
       callback(key, message) {
-        translationObject[key] = message;
+        translationJson[key] = message;
       },
       prefix,
     });
@@ -91,5 +91,5 @@ export function extractTranslations(
     // Do nothing
   }
 
-  return translationObject;
+  return translationJson;
 }

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/base-case.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/base-case.test.ts
@@ -58,13 +58,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     'routes.products.title': 'Products',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.json',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/edge-case-folder-name-has-space.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/edge-case-folder-name-has-space.test.ts
@@ -15,13 +15,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     title: '{productName}',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/  things for  product /en-us.json',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     '  things for  product .card.learn-more.aria-label':
       'Learn more about {productName}',
     '  things for  product .card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/file-is-empty.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/file-is-empty.test.ts
@@ -5,11 +5,11 @@ import { extractTranslations } from '../../../../../../src/utils/analyze-project
 test('utils | analyze-project | merge-translation-files | extract-translations | json > file is empty', function () {
   const file = '';
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.json',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {});
+  assert.deepStrictEqual(translationJson, {});
 });

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-1.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-1.test.ts
@@ -15,13 +15,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     title: '{productName}',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.json',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'card.learn-more.aria-label': 'Learn more about {productName}',
     'card.learn-more.label': 'Learn more',
     'details.add-to-cart': 'Add to Cart',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-2.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-2.test.ts
@@ -15,13 +15,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     title: '{productName}',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/components/products/product/en-us.json',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-3.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-3.test.ts
@@ -21,13 +21,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     title: '{productName}',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/components/products/product/en-us.json',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-nested.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-nested.test.ts
@@ -103,13 +103,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     },
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.json',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/base-case.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/base-case.test.ts
@@ -52,13 +52,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.yaml',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/edge-case-folder-name-has-space.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/edge-case-folder-name-has-space.test.ts
@@ -16,13 +16,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/  things for  product /en-us.yaml',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     '  things for  product .card.learn-more.aria-label':
       'Learn more about {productName}',
     '  things for  product .card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/file-is-empty.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/file-is-empty.test.ts
@@ -5,11 +5,11 @@ import { extractTranslations } from '../../../../../../src/utils/analyze-project
 test('utils | analyze-project | merge-translation-files | extract-translations | yaml > file is empty', function () {
   const file = '';
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.yaml',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {});
+  assert.deepStrictEqual(translationJson, {});
 });

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-1.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-1.test.ts
@@ -16,13 +16,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.yaml',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'card.learn-more.aria-label': 'Learn more about {productName}',
     'card.learn-more.label': 'Learn more',
     'details.add-to-cart': 'Add to Cart',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-2.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-2.test.ts
@@ -16,13 +16,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/components/products/product/en-us.yaml',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-3.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-3.test.ts
@@ -19,13 +19,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/components/products/product/en-us.yaml',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-nested.test.ts
+++ b/packages/ember-intl-lint/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-nested.test.ts
@@ -81,13 +81,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.yaml',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-v1-compat/lib/broccoli/translation-reducer.js
+++ b/packages/ember-intl-v1-compat/lib/broccoli/translation-reducer.js
@@ -4,6 +4,7 @@ const CachingWriter = require('broccoli-caching-writer');
 const extend = require('extend');
 const stringify = require('json-stable-stringify');
 
+const flattenKeys = require('../utils/translation-reducer/flatten-keys');
 const getTranslations = require('../utils/translation-reducer/get-translations');
 const namespaceKeys = require('../utils/translation-reducer/namespace-keys');
 
@@ -45,16 +46,16 @@ class TranslationReducer extends CachingWriter {
     const translations = this.mergeTranslations(translationFilePaths);
 
     const filePath = join(this.outputPath, this.options.outputPath);
-    const fallbackTranslationObject = translations[this.options.fallbackLocale];
+    const fallbackTranslationJson = translations[this.options.fallbackLocale];
 
     mkdirSync(filePath, { recursive: true });
 
     for (const locale in translations) {
-      if (fallbackTranslationObject && this.options.fallbackLocale !== locale) {
+      if (fallbackTranslationJson && this.options.fallbackLocale !== locale) {
         translations[locale] = extend(
           true,
           {},
-          fallbackTranslationObject,
+          fallbackTranslationJson,
           translations[locale],
         );
       }
@@ -119,6 +120,13 @@ class TranslationReducer extends CachingWriter {
           translationsDir: this.inputPaths[0],
         });
       }
+
+      translationObject = flattenKeys(translationObject, {
+        callback(key, message) {
+          translationObject[key] = message;
+        },
+        prefix: '',
+      });
 
       const fileName = basename(filePath).split('.')[0];
       const locale = normalizeLocale(fileName);

--- a/packages/ember-intl-v1-compat/lib/utils/translation-reducer/flatten-keys.js
+++ b/packages/ember-intl-v1-compat/lib/utils/translation-reducer/flatten-keys.js
@@ -1,0 +1,35 @@
+function traverse(json, data) {
+  for (const key in json) {
+    if (!Object.hasOwn(json, key)) {
+      continue;
+    }
+
+    const value = json[key];
+
+    if (typeof value === 'object') {
+      traverse(value, {
+        callback: data.callback,
+        prefix: `${data.prefix}${key}.`,
+      });
+
+      continue;
+    }
+
+    data.callback(`${data.prefix}${key}`, value);
+  }
+}
+
+function flattenKeys(json) {
+  const translationJson = {};
+
+  traverse(json, {
+    callback(key, message) {
+      translationJson[key] = message;
+    },
+    prefix: '',
+  });
+
+  return translationJson;
+}
+
+module.exports = flattenKeys;

--- a/packages/ember-intl-v1-compat/lib/utils/translation-reducer/get-translations.js
+++ b/packages/ember-intl-v1-compat/lib/utils/translation-reducer/get-translations.js
@@ -4,9 +4,10 @@ const { load } = require('js-yaml');
 
 function getTranslations(filePath) {
   const file = readFileSync(filePath, 'utf8');
+  const translationJson = {};
 
   if (file === '') {
-    return {};
+    return translationJson;
   }
 
   const ext = extname(filePath);
@@ -18,15 +19,15 @@ function getTranslations(filePath) {
 
     case '.yaml':
     case '.yml': {
-      let translations = {};
+      let translationJson = {};
 
       try {
-        translations = load(file);
+        translationJson = load(file);
       } catch {
         // Do nothing
       }
 
-      return translations;
+      return translationJson;
     }
   }
 }

--- a/packages/ember-intl-v1-compat/lib/utils/translation-reducer/namespace-keys.js
+++ b/packages/ember-intl-v1-compat/lib/utils/translation-reducer/namespace-keys.js
@@ -4,7 +4,7 @@ const { dirname, normalize, sep } = require('node:path');
  * Wraps the root object with a namespace.
  *
  * If the file `translations/foo/bar/en-us.json` has a `baz` key,
- * then `translationObject` will have `foo.bar.baz` instead.
+ * then `translationJson` will have `foo.bar.baz` instead.
  */
 function namespaceKeys(translations, data) {
   const { addonNames, filePath, translationsDir } = data;

--- a/packages/ember-intl-vite/src/steps/analyze-project/merge-translation-files.ts
+++ b/packages/ember-intl-vite/src/steps/analyze-project/merge-translation-files.ts
@@ -24,7 +24,7 @@ export function mergeTranslationFiles(
   translationFiles.forEach((data, filePath) => {
     const file = readFileSync(join(projectRoot, filePath), 'utf8');
 
-    const translationObject = extractTranslations(file, {
+    const translationJson = extractTranslations(file, {
       filePath,
       namespaceKeysByDir: buildOptions.namespaceKeysByDir,
       translationsDir: data.translationsDir,
@@ -34,7 +34,7 @@ export function mergeTranslationFiles(
       translations.get(data.locale) ??
       new Map<TranslationKey, ProjectTranslationData>();
 
-    for (const [key, message] of Object.entries(translationObject)) {
+    for (const [key, message] of Object.entries(translationJson)) {
       keyToData.set(key, {
         filePath,
         message,

--- a/packages/ember-intl-vite/src/steps/get-translation-file.ts
+++ b/packages/ember-intl-vite/src/steps/get-translation-file.ts
@@ -1,6 +1,6 @@
 import { EOL } from 'node:os';
 
-import type { Locale, Project, TranslationObject } from '../types/index.js';
+import type { Locale, Project, TranslationJson } from '../types/index.js';
 
 export function getTranslationFile(
   translations: Project['translations'],
@@ -14,14 +14,14 @@ export function getTranslationFile(
     );
   }
 
-  const translationObject: TranslationObject = {};
+  const translationJson: TranslationJson = {};
 
   keyToData.forEach((data, key) => {
-    translationObject[key] = data.message;
+    translationJson[key] = data.message;
   });
 
   return [
-    `const translations = ${JSON.stringify(translationObject)};`,
+    `const translations = ${JSON.stringify(translationJson)};`,
     `export default translations;`,
   ].join(EOL);
 }

--- a/packages/ember-intl-vite/src/types/index.ts
+++ b/packages/ember-intl-vite/src/types/index.ts
@@ -37,15 +37,11 @@ type ProjectTranslationData = {
 
 type TranslationFilePath = string;
 
-type TranslationJson = {
-  [key: TranslationKey]: TranslationJson | TranslationMessage;
-};
+type TranslationJson = Record<TranslationKey, TranslationMessage>;
 
 type TranslationKey = string;
 
 type TranslationMessage = string;
-
-type TranslationObject = Record<TranslationKey, TranslationMessage>;
 
 type UserConfig = Partial<{
   addonPaths: string[];
@@ -63,6 +59,5 @@ export type {
   TranslationJson,
   TranslationKey,
   TranslationMessage,
-  TranslationObject,
   UserConfig,
 };

--- a/packages/ember-intl-vite/src/utils/analyze-project/merge-translation-files/extract-translations.ts
+++ b/packages/ember-intl-vite/src/utils/analyze-project/merge-translation-files/extract-translations.ts
@@ -8,13 +8,16 @@ import type {
   TranslationJson,
   TranslationKey,
   TranslationMessage,
-  TranslationObject,
 } from '../../../types/index.js';
 
 type Data = {
   filePath: TranslationFilePath;
   namespaceKeysByDir: boolean;
   translationsDir: string;
+};
+
+type TranslationJsonRaw = {
+  [key: TranslationKey]: TranslationJsonRaw | TranslationMessage;
 };
 
 function getPrefix(data: Data): string {
@@ -35,18 +38,18 @@ function getPrefix(data: Data): string {
 }
 
 function traverse(
-  translationJson: TranslationJson,
+  json: TranslationJsonRaw,
   data: {
     callback: (key: TranslationKey, message: TranslationMessage) => void;
     prefix: string;
   },
 ): void {
-  for (const key in translationJson) {
-    if (!Object.hasOwn(translationJson, key)) {
+  for (const key in json) {
+    if (!Object.hasOwn(json, key)) {
       continue;
     }
 
-    const value = translationJson[key]!;
+    const value = json[key]!;
 
     if (typeof value === 'object') {
       traverse(value, {
@@ -61,29 +64,26 @@ function traverse(
   }
 }
 
-export function extractTranslations(
-  file: string,
-  data: Data,
-): TranslationObject {
-  const translationObject: TranslationObject = {};
+export function extractTranslations(file: string, data: Data): TranslationJson {
+  const translationJson: TranslationJson = {};
 
   if (file === '') {
-    return translationObject;
+    return translationJson;
   }
 
   const { ext } = parseFilePath(data.filePath);
 
   try {
-    const translationJson =
+    const json =
       ext === '.json'
-        ? (JSON.parse(file) as TranslationJson)
-        : (load(file) as TranslationJson);
+        ? (JSON.parse(file) as TranslationJsonRaw)
+        : (load(file) as TranslationJsonRaw);
 
     const prefix = getPrefix(data);
 
-    traverse(translationJson, {
+    traverse(json, {
       callback(key, message) {
-        translationObject[key] = message;
+        translationJson[key] = message;
       },
       prefix,
     });
@@ -91,5 +91,5 @@ export function extractTranslations(
     // Do nothing
   }
 
-  return translationObject;
+  return translationJson;
 }

--- a/packages/ember-intl-vite/src/virtual.d.ts
+++ b/packages/ember-intl-vite/src/virtual.d.ts
@@ -1,6 +1,4 @@
-type TranslationJson = {
-  [key: TranslationKey]: TranslationJson | TranslationMessage;
-};
+type TranslationJson = Record<TranslationKey, TranslationMessage>;
 
 type TranslationKey = string;
 

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/base-case.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/base-case.test.ts
@@ -58,13 +58,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     'routes.products.title': 'Products',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.json',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/edge-case-folder-name-has-space.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/edge-case-folder-name-has-space.test.ts
@@ -15,13 +15,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     title: '{productName}',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/  things for  product /en-us.json',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     '  things for  product .card.learn-more.aria-label':
       'Learn more about {productName}',
     '  things for  product .card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/file-is-empty.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/file-is-empty.test.ts
@@ -5,11 +5,11 @@ import { extractTranslations } from '../../../../../../src/utils/analyze-project
 test('utils | analyze-project | merge-translation-files | extract-translations | json > file is empty', function () {
   const file = '';
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.json',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {});
+  assert.deepStrictEqual(translationJson, {});
 });

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-1.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-1.test.ts
@@ -15,13 +15,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     title: '{productName}',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.json',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'card.learn-more.aria-label': 'Learn more about {productName}',
     'card.learn-more.label': 'Learn more',
     'details.add-to-cart': 'Add to Cart',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-2.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-2.test.ts
@@ -15,13 +15,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     title: '{productName}',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/components/products/product/en-us.json',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-3.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-namespaced-3.test.ts
@@ -21,13 +21,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     title: '{productName}',
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/components/products/product/en-us.json',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-nested.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/json/keys-are-nested.test.ts
@@ -103,13 +103,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     },
   });
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.json',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/base-case.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/base-case.test.ts
@@ -52,13 +52,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.yaml',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/edge-case-folder-name-has-space.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/edge-case-folder-name-has-space.test.ts
@@ -16,13 +16,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/  things for  product /en-us.yaml',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     '  things for  product .card.learn-more.aria-label':
       'Learn more about {productName}',
     '  things for  product .card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/file-is-empty.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/file-is-empty.test.ts
@@ -5,11 +5,11 @@ import { extractTranslations } from '../../../../../../src/utils/analyze-project
 test('utils | analyze-project | merge-translation-files | extract-translations | yaml > file is empty', function () {
   const file = '';
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.yaml',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {});
+  assert.deepStrictEqual(translationJson, {});
 });

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-1.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-1.test.ts
@@ -16,13 +16,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.yaml',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'card.learn-more.aria-label': 'Learn more about {productName}',
     'card.learn-more.label': 'Learn more',
     'details.add-to-cart': 'Add to Cart',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-2.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-2.test.ts
@@ -16,13 +16,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/components/products/product/en-us.yaml',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-3.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-namespaced-3.test.ts
@@ -19,13 +19,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/components/products/product/en-us.yaml',
     namespaceKeysByDir: true,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-nested.test.ts
+++ b/packages/ember-intl-vite/tests/utils/analyze-project/merge-translation-files/extract-translations/yaml/keys-are-nested.test.ts
@@ -81,13 +81,13 @@ test('utils | analyze-project | merge-translation-files | extract-translations |
     ``,
   ]);
 
-  const translationObject = extractTranslations(file, {
+  const translationJson = extractTranslations(file, {
     filePath: 'translations/en-us.yaml',
     namespaceKeysByDir: false,
     translationsDir: 'translations',
   });
 
-  assert.deepStrictEqual(translationObject, {
+  assert.deepStrictEqual(translationJson, {
     'components.products.product.card.learn-more.aria-label':
       'Learn more about {productName}',
     'components.products.product.card.learn-more.label': 'Learn more',

--- a/packages/ember-intl/src/-private/utils/translations.ts
+++ b/packages/ember-intl/src/-private/utils/translations.ts
@@ -2,40 +2,4 @@ type TranslationKey = string;
 
 type TranslationMessage = string;
 
-export type TranslationJson = {
-  [key: TranslationKey]: TranslationJson | TranslationMessage;
-};
-
-/**
- * @private
- */
-export function flattenKeys(object: TranslationJson): TranslationJson {
-  const result: TranslationJson = {};
-
-  for (const key in object) {
-    if (!Object.prototype.hasOwnProperty.call(object, key)) {
-      continue;
-    }
-
-    const value = object[key];
-
-    // If `value` is not `null`
-    if (value && typeof value === 'object') {
-      const hash = flattenKeys(value);
-
-      for (const suffix in hash) {
-        const translation = hash[suffix];
-
-        if (typeof translation !== 'undefined') {
-          result[`${key}.${suffix}`] = translation;
-        }
-      }
-    } else {
-      if (typeof value !== 'undefined') {
-        result[key] = value;
-      }
-    }
-  }
-
-  return result;
-}
+export type TranslationJson = Record<TranslationKey, TranslationMessage>;

--- a/packages/ember-intl/src/services/intl.ts
+++ b/packages/ember-intl/src/services/intl.ts
@@ -37,10 +37,7 @@ import {
   hasLocaleChanged,
   normalizeLocale,
 } from '../-private/utils/locale.ts';
-import {
-  flattenKeys,
-  type TranslationJson,
-} from '../-private/utils/translations.ts';
+import type { TranslationJson } from '../-private/utils/translations.ts';
 
 export type { Formats };
 
@@ -97,9 +94,7 @@ export default class IntlService extends Service {
   }
 
   addTranslations(locale: string, translations: TranslationJson): void {
-    const messages = flattenKeys(translations);
-
-    this.updateIntl(locale, messages);
+    this.updateIntl(locale, translations);
   }
 
   private createIntl(

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/ignores-unknown-locales.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/ignores-unknown-locales.test.ts
@@ -24,9 +24,9 @@ test('lib | broccoli | translation-reducer | base case > ignores unknown locales
   const translationsDir = await buildTranslationsDir(outputNode);
 
   assert.deepStrictEqual(translationsDir, {
-    'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+    'en-us.json': `{"nested.key":"Hello {name}!","no-arguments":"Hello world!"}`,
     'unknown-language.json':
-      '{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}',
+      '{"nested.key":"Hallo {name}!","no-arguments":"Hallo Welt!"}',
   });
 
   assert.deepStrictEqual(logs, []);

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/it-works.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/it-works.test.ts
@@ -18,7 +18,7 @@ test('lib | broccoli | translation-reducer | base case > it works', async functi
   const translationsDir = await buildTranslationsDir(outputNode);
 
   assert.deepStrictEqual(translationsDir, {
-    'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
-    'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+    'de-de.json': `{"nested.key":"Hallo {name}!","no-arguments":"Hallo Welt!"}`,
+    'en-us.json': `{"nested.key":"Hello {name}!","no-arguments":"Hello world!"}`,
   });
 });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/mergeTranslationFiles-is-true.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/base-case/mergeTranslationFiles-is-true.test.ts
@@ -20,9 +20,9 @@ test('lib | broccoli | translation-reducer | base case > mergeTranslationFiles i
   const translationsDir = await buildTranslationsDir(outputNode);
 
   assert.deepStrictEqual(translationsDir, {
-    'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
-    'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+    'de-de.json': `{"nested.key":"Hallo {name}!","no-arguments":"Hallo Welt!"}`,
+    'en-us.json': `{"nested.key":"Hello {name}!","no-arguments":"Hello world!"}`,
     'translations.js':
-      'export default [["de-de",{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}],["en-us",{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}]]',
+      'export default [["de-de",{"nested.key":"Hallo {name}!","no-arguments":"Hallo Welt!"}],["en-us",{"nested.key":"Hello {name}!","no-arguments":"Hello world!"}]]',
   });
 });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/fallbackLocale/does-not-overwrite-user-provided-translations.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/fallbackLocale/does-not-overwrite-user-provided-translations.test.ts
@@ -20,7 +20,7 @@ test('lib | broccoli | translation-reducer | fallbackLocale > does not overwrite
   const translationsDir = await buildTranslationsDir(outputNode);
 
   assert.deepStrictEqual(translationsDir, {
-    'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
-    'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+    'de-de.json': `{"nested.key":"Hallo {name}!","no-arguments":"Hallo Welt!"}`,
+    'en-us.json': `{"nested.key":"Hello {name}!","no-arguments":"Hello world!"}`,
   });
 });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/fallbackLocale/falls-back-for-missing-translations.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/fallbackLocale/falls-back-for-missing-translations.test.ts
@@ -20,7 +20,7 @@ test('lib | broccoli | translation-reducer | fallbackLocale > falls back for mis
   const translationsDir = await buildTranslationsDir(outputNode);
 
   assert.deepStrictEqual(translationsDir, {
-    'de-de.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
-    'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+    'de-de.json': `{"nested.key":"Hello {name}!","no-arguments":"Hello world!"}`,
+    'en-us.json': `{"nested.key":"Hello {name}!","no-arguments":"Hello world!"}`,
   });
 });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/edge-case-folder-name-has-space.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/edge-case-folder-name-has-space.test.ts
@@ -39,17 +39,17 @@ test('lib | broccoli | translation-reducer | mergeTranslations > edge case (fold
 
   assert.deepStrictEqual(translations, {
     'en-us': {
-      '  things for  product ': {
-        'card.learn-more.aria-label': 'Learn more about {productName}',
-        'card.learn-more.label': 'Learn more',
-        'details.add-to-cart': 'Add to Cart',
-        'details.description': 'Description',
-        'details.price': 'Price',
-        'details.rating': 'Rating',
-        'details.rating-value': '{productRating} out of 5 stars',
-        'details.seller': 'Seller',
-        title: '{productName}',
-      },
+      '  things for  product .card.learn-more.aria-label':
+        'Learn more about {productName}',
+      '  things for  product .card.learn-more.label': 'Learn more',
+      '  things for  product .details.add-to-cart': 'Add to Cart',
+      '  things for  product .details.description': 'Description',
+      '  things for  product .details.price': 'Price',
+      '  things for  product .details.rating': 'Rating',
+      '  things for  product .details.rating-value':
+        '{productRating} out of 5 stars',
+      '  things for  product .details.seller': 'Seller',
+      '  things for  product .title': '{productName}',
     },
   });
 });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/it-does-not-remove-empty-translations.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/it-does-not-remove-empty-translations.test.ts
@@ -35,17 +35,12 @@ test('lib | broccoli | translation-reducer | mergeTranslations > it does not rem
 
   assert.deepStrictEqual(translations, {
     'de-de': {
-      sample_translation: {
-        translation_1: 'Lorem ipsum',
-        translation_2: '',
-        translation_3: null,
-      },
+      'sample_translation.translation_1': 'Lorem ipsum',
+      'sample_translation.translation_2': '',
     },
     'en-us': {
-      sample_translation: {
-        translation_1: 'Lorem ipsum',
-        translation_2: 'dolor sit amet',
-      },
+      'sample_translation.translation_1': 'Lorem ipsum',
+      'sample_translation.translation_2': 'dolor sit amet',
     },
   });
 });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-addon-2.test.ts
@@ -45,14 +45,10 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
 
   assert.deepStrictEqual(translations, {
     'en-us': {
-      components: {
-        foo: 'bar',
-        hello: {
-          message: 'Hello, {name}!',
-          title: '<Hello> component',
-        },
-        title: 'Components',
-      },
+      'components.foo': 'bar',
+      'components.hello.message': 'Hello, {name}!',
+      'components.hello.title': '<Hello> component',
+      'components.title': 'Components',
       title: 'Homepage',
     },
   });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-2.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/mergeTranslations/translations-from-app-2.test.ts
@@ -38,14 +38,10 @@ test('lib | broccoli | translation-reducer | mergeTranslations > translations fr
 
   assert.deepStrictEqual(translations, {
     'en-us': {
-      components: {
-        foo: 'bar',
-        hello: {
-          message: 'Hello, {name}!',
-          title: '<Hello> component',
-        },
-        title: 'Components',
-      },
+      'components.foo': 'bar',
+      'components.hello.message': 'Hello, {name}!',
+      'components.hello.title': '<Hello> component',
+      'components.title': 'Components',
       title: 'Homepage',
     },
   });

--- a/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/outputPath/it-works.test.ts
+++ b/tests/ember-intl-v1-compat/tests/lib/broccoli/translation-reducer/outputPath/it-works.test.ts
@@ -23,8 +23,8 @@ test('lib | broccoli | translation-reducer | outputPath > it works', async funct
     custom: {
       output: {
         path: {
-          'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
-          'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+          'de-de.json': `{"nested.key":"Hallo {name}!","no-arguments":"Hallo Welt!"}`,
+          'en-us.json': `{"nested.key":"Hello {name}!","no-arguments":"Hello world!"}`,
         },
       },
     },

--- a/tests/ember-intl/tests/integration/components/lazy-hello-test.gts
+++ b/tests/ember-intl/tests/integration/components/lazy-hello-test.gts
@@ -12,9 +12,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
 
     test('Translations are loaded before the component is rendered', async function (assert) {
       await addTranslations('en-us', {
-        'lazy-hello': {
-          message: 'Hello, {name}!',
-        },
+        'lazy-hello.message': 'Hello, {name}!',
       });
 
       await render(<template><LazyHello @name="Zoey" /></template>);
@@ -43,9 +41,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
         );
 
       await addTranslations('en-us', {
-        'lazy-hello': {
-          message: 'Hello, {name}!',
-        },
+        'lazy-hello.message': 'Hello, {name}!',
       });
 
       assert
@@ -65,9 +61,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       addTranslations('en-us', {
-        'lazy-hello': {
-          message: 'Hello, {name}!',
-        },
+        'lazy-hello.message': 'Hello, {name}!',
       });
 
       assert
@@ -88,9 +82,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
 
     test('Translations are loaded before the component is rendered', async function (assert) {
       await addTranslations('de-de', {
-        'lazy-hello': {
-          message: 'Hallo, {name}!',
-        },
+        'lazy-hello.message': 'Hallo, {name}!',
       });
 
       await render(<template><LazyHello @name="Zoey" /></template>);
@@ -119,9 +111,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
         );
 
       await addTranslations('de-de', {
-        'lazy-hello': {
-          message: 'Hallo, {name}!',
-        },
+        'lazy-hello.message': 'Hallo, {name}!',
       });
 
       assert
@@ -141,9 +131,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       addTranslations('de-de', {
-        'lazy-hello': {
-          message: 'Hallo, {name}!',
-        },
+        'lazy-hello.message': 'Hallo, {name}!',
       });
 
       assert

--- a/tests/ember-intl/tests/integration/helpers/t/data-provided-as-an-object-test.gts
+++ b/tests/ember-intl/tests/integration/helpers/t/data-provided-as-an-object-test.gts
@@ -20,16 +20,12 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
     setupIntl(hooks, 'de-de', {
-      population: {
-        description:
-          '{city} hat eine Bevölkerung von {population, number, integer} zum {censusDate, date, long}.',
-      },
+      'population.description':
+        '{city} hat eine Bevölkerung von {population, number, integer} zum {censusDate, date, long}.',
     });
     setupIntl(hooks, 'en-us', {
-      population: {
-        description:
-          '{city} has a population of {population, number, integer} as of {censusDate, date, long}.',
-      },
+      'population.description':
+        '{city} has a population of {population, number, integer} as of {censusDate, date, long}.',
     });
 
     hooks.beforeEach(function (this: TestContext) {

--- a/tests/ember-intl/tests/integration/helpers/t/translation-has-html-code-test.gts
+++ b/tests/ember-intl/tests/integration/helpers/t/translation-has-html-code-test.gts
@@ -17,16 +17,12 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
     setupIntl(hooks, 'de-de', {
-      royalty: {
-        message:
-          '<div class="message">Hallo, {name}! Du hast {points, number} Treuepunkte.</div>',
-      },
+      'royalty.message':
+        '<div class="message">Hallo, {name}! Du hast {points, number} Treuepunkte.</div>',
     });
     setupIntl(hooks, 'en-us', {
-      royalty: {
-        message:
-          '<div class="message">Hello, {name}! You have {points, number} royalty points.</div>',
-      },
+      'royalty.message':
+        '<div class="message">Hello, {name}! You have {points, number} royalty points.</div>',
     });
 
     hooks.beforeEach(function (this: TestContext) {

--- a/tests/ember-intl/tests/unit/services/intl/addTranslations-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl/addTranslations-test.ts
@@ -41,13 +41,9 @@ module('Unit | Service | intl > addTranslations', function (hooks) {
 
   test('keys can include a period', function (this: TestContext, assert) {
     this.intl.addTranslations('en-us', {
-      foo: {
-        'bar.baz': 'Hello!',
-      },
+      'foo.bar.baz': 'Hello!',
       'foo2.bar.baz': 'Hi!',
-      'foo3.bar': {
-        baz: 'Bye!',
-      },
+      'foo3.bar.baz': 'Bye!',
     });
 
     assert.strictEqual(this.intl.t('foo.bar.baz'), 'Hello!');
@@ -57,21 +53,12 @@ module('Unit | Service | intl > addTranslations', function (hooks) {
 
   test('can be called multiple times', function (this: TestContext, assert) {
     this.intl.addTranslations('en-us', {
-      foo: {
-        bar: {
-          baz: 'Hello!',
-        },
-      },
+      'foo.bar.baz': 'Hello!',
     });
 
     this.intl.addTranslations('en-us', {
-      foo: {
-        bar: {
-          baz: 'Hi!',
-          quux: 'Bye!',
-        },
-        bar2: {},
-      },
+      'foo.bar.baz': 'Hi!',
+      'foo.bar.quux': 'Bye!',
     });
 
     assert.strictEqual(this.intl.t('foo.bar.baz'), 'Hi!');

--- a/tests/ember-intl/tests/unit/services/intl/exists-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl/exists-test.ts
@@ -47,19 +47,11 @@ module('Unit | Service | intl > exists', function (hooks) {
 
     test('returns true, if and only if, the key exists for an active locale (3)', function (this: TestContext, assert) {
       this.intl.addTranslations('de-de', {
-        foo1: {
-          bar: {
-            baz: 'Hallo!',
-          },
-        },
+        'foo1.bar.baz': 'Hallo!',
       });
 
       this.intl.addTranslations('en-us', {
-        foo2: {
-          bar: {
-            baz: 'Hello!',
-          },
-        },
+        'foo2.bar.baz': 'Hello!',
       });
 
       this.intl.setLocale(['de-de', 'en-us']);
@@ -118,19 +110,11 @@ module('Unit | Service | intl > exists', function (hooks) {
 
     test('returns true, if and only if, the key exists for the specified locale (3)', function (this: TestContext, assert) {
       this.intl.addTranslations('de-de', {
-        foo1: {
-          bar: {
-            baz: 'Hallo!',
-          },
-        },
+        'foo1.bar.baz': 'Hallo!',
       });
 
       this.intl.addTranslations('en-us', {
-        foo2: {
-          bar: {
-            baz: 'Hello!',
-          },
-        },
+        'foo2.bar.baz': 'Hello!',
       });
 
       this.intl.setLocale(['en-us']);


### PR DESCRIPTION
## Why?

From `5.x` to `7.x`, the `intl` service's `addTranslations` flattened a translation JSON (data representation of translation files), because the Node part of the addon, which was responsible for reading translation files, didn't handle flattening.

In `8.x`, `addTranslations` continued to flatten a JSON even though `@ember-intl/vite` had already flattened it, because `@ember-intl/v1-compat` didn't handle flattening. That is, Vite apps encounter an unnecessary cost, while maintaining the `ember-intl` project is more difficult due to different implemenations and unclear boundaries.


## Solution?

Going forward, all packages that load translations (i.e. `lint`, `v1-compat`, and `vite`) will be responsible for flattening a translation JSON.

When an end-developer calls `intl.addTranslations()`, they will need to ensure that `translations` (the 2nd parameter) is flat. The call happen when they use the test helper `addTranslations` or `setupIntl` with `translations` (the 3rd parameter used to stub translations).
