### PR TITLE
Improved documentation search

### DIFF
--- a/.changeset/itchy-geese-dig.md
+++ b/.changeset/itchy-geese-dig.md
@@ -1,0 +1,5 @@
+---
+"docs-app-for-ember-intl": minor
+---
+
+Improved documentation search

--- a/docs/ember-intl/.vitepress/config.mts
+++ b/docs/ember-intl/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { loadTranslations } from '@ember-intl/vite';
 import { defineConfig } from 'vitepress';
 import vitePluginEmber, { emberFence } from 'vite-plugin-ember';
 
+import { miniSearch } from './minisearch.mts';
 import { sidebar } from './sidebar.mts';
 
 export default defineConfig({
@@ -96,6 +97,10 @@ export default defineConfig({
       level: [2, 3],
     },
     search: {
+      options: {
+        detailedView: true,
+        miniSearch,
+      },
       provider: 'local',
     },
     sidebar,

--- a/docs/ember-intl/.vitepress/minisearch.mts
+++ b/docs/ember-intl/.vitepress/minisearch.mts
@@ -1,0 +1,42 @@
+import type { DefaultTheme } from 'vitepress/theme';
+
+/*
+  MiniSearch's default tokenizer splits on whitespace and punctuation only, so
+  an API name like `formatDateRange` is indexed as a single term. We split
+  camelCase names as well, so that someone who searches for "date range" or
+  "primary locale" lands on the same pages that `formatDateRange` and
+  `primaryLocale` do.
+*/
+const SPACE_OR_PUNCTUATION = /[\n\r\p{Z}\p{P}]+/u;
+
+const CAMEL_CASE_BOUNDARY =
+  /(?<=[\p{Ll}\p{N}])(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/u;
+
+function tokenize(text: string): string[] {
+  const tokens: string[] = [];
+
+  for (const word of text.split(SPACE_OR_PUNCTUATION)) {
+    if (word === '') {
+      continue;
+    }
+
+    // Keep the whole name, so that searching for `formatDateRange` still works
+    tokens.push(word);
+
+    const parts = word.split(CAMEL_CASE_BOUNDARY);
+
+    if (parts.length > 1) {
+      tokens.push(...parts);
+    }
+  }
+
+  return tokens;
+}
+
+export const miniSearch: NonNullable<
+  DefaultTheme.LocalSearchOptions['miniSearch']
+> = {
+  options: {
+    tokenize,
+  },
+};

--- a/docs/ember-intl/.vitepress/minisearch.mts
+++ b/docs/ember-intl/.vitepress/minisearch.mts
@@ -1,32 +1,107 @@
 import type { DefaultTheme } from 'vitepress/theme';
 
-/*
-  MiniSearch's default tokenizer splits on whitespace and punctuation only, so
-  an API name like `formatDateRange` is indexed as a single term. We split
-  camelCase names as well, so that someone who searches for "date range" or
-  "primary locale" lands on the same pages that `formatDateRange` and
-  `primaryLocale` do.
-*/
-const SPACE_OR_PUNCTUATION = /[\n\r\p{Z}\p{P}]+/u;
+function boostDocument(documentId: string, term: string): number {
+  const [url, _sectionId] = documentId.split('#') as [
+    string,
+    string | undefined,
+  ];
 
-const CAMEL_CASE_BOUNDARY =
-  /(?<=[\p{Ll}\p{N}])(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/u;
+  const path = url.replace('/ember-intl/docs', '');
+
+  const HELPER_PAGES: Record<string, string> = {
+    formatdate: '/helpers/format-date',
+    formatdaterange: '/helpers/format-date-range',
+    formatdisplayname: '/helpers/format-display-name',
+    formatlist: '/helpers/format-list',
+    formatmessage: '/helpers/format-message',
+    formatnumber: '/helpers/format-number',
+    formatrelativetime: '/helpers/format-relative-time',
+    formattime: '/helpers/format-time',
+    t: '/helpers/t',
+    tkey: '/helpers/t-key',
+  };
+
+  const helperPage = HELPER_PAGES[term.toLowerCase()];
+
+  if (helperPage) {
+    return path === helperPage ? 10 : 0;
+  }
+
+  if (path === '/') {
+    return 0.5;
+  }
+
+  if (path === '/quickstart') {
+    return 3;
+  }
+
+  if (path === '/quickstart-addons') {
+    return 2;
+  }
+
+  if (path.startsWith('/advanced/')) {
+    return 1.5;
+  }
+
+  if (path.startsWith('/helpers/')) {
+    return 5;
+  }
+
+  if (path.startsWith('/migration/')) {
+    return 1;
+  }
+
+  if (path.startsWith('/services/')) {
+    return 3;
+  }
+
+  if (path.startsWith('/test-helpers/')) {
+    return 1;
+  }
+
+  return 1;
+}
 
 function tokenize(text: string): string[] {
+  /*
+    MiniSearch's default tokenizer splits on whitespace and punctuation only, so
+    an API name like `formatDateRange` is indexed as a single term. We split
+    camelCase names as well, so that someone who searches for "date range" or
+    "primary locale" lands on the same pages that `formatDateRange` and
+    `primaryLocale` do.
+  */
+  const SPACE = /[\n\r\p{Z}]+/u;
+
+  const PUNCTUATION = /\p{P}+/u;
+
+  const CAMEL_CASE_BOUNDARY =
+    /(?<=[\p{Ll}\p{N}])(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/u;
+
   const tokens: string[] = [];
 
-  for (const word of text.split(SPACE_OR_PUNCTUATION)) {
-    if (word === '') {
-      continue;
+  for (const chunk of text.split(SPACE)) {
+    const words = chunk.split(PUNCTUATION).filter((word) => word !== '');
+
+    for (const word of words) {
+      // Keep the whole name, so that searching for `formatDateRange` still works
+      tokens.push(word);
+
+      const parts = word.split(CAMEL_CASE_BOUNDARY);
+
+      if (parts.length > 1) {
+        tokens.push(...parts);
+      }
     }
 
-    // Keep the whole name, so that searching for `formatDateRange` still works
-    tokens.push(word);
-
-    const parts = word.split(CAMEL_CASE_BOUNDARY);
-
-    if (parts.length > 1) {
-      tokens.push(...parts);
+    /*
+      Join what punctuation split apart, so that `format-date-range` produces
+      the same `formatdaterange` token that `formatDateRange` does. Both
+      spellings of a name then lead to the same page. (A user who types the
+      words with a space instead, `format date range`, still gets the looser,
+      word-by-word match.)
+    */
+    if (words.length > 1) {
+      tokens.push(words.join(''));
     }
   }
 
@@ -38,5 +113,8 @@ export const miniSearch: NonNullable<
 > = {
   options: {
     tokenize,
+  },
+  searchOptions: {
+    boostDocument,
   },
 };


### PR DESCRIPTION
## What changed?

Configured `minisearch` so that it assigns a greater weight to certain pages. I created the `tokenize` method using Claude Code.


## References

- https://lucaong.github.io/minisearch/types/MiniSearch.Options.html
- https://lucaong.github.io/minisearch/types/MiniSearch.SearchOptions.html
- https://vitepress.dev/reference/default-theme-search#minisearch-options


## Examples

The left tab shows before, the right tab after.

![Search results for t](https://github.com/user-attachments/assets/fa19cabd-a3d3-460d-ab42-75e9aa0b167c)

![Search results for date](https://github.com/user-attachments/assets/e9d7ec4e-375e-4cea-b3a3-3c5fd6ac3950)

![Search results for vite](https://github.com/user-attachments/assets/eb326823-1105-4f00-9230-30d1744b9564)

![Search results for lazy](https://github.com/user-attachments/assets/2474663e-a583-4d20-9411-ea8cdef66e5c)
