### PR TITLE
Strictened types for primaryLocale and setLocale()

### DIFF
--- a/.changeset/orange-baboons-punch.md
+++ b/.changeset/orange-baboons-punch.md
@@ -1,0 +1,8 @@
+---
+"ember-intl": major
+"docs-app-for-ember-intl": minor
+"my-v2-addon": minor
+"test-app-for-ember-intl": minor
+---
+
+Strictened type for `setLocale()`

--- a/.changeset/primary-locale-definite.md
+++ b/.changeset/primary-locale-definite.md
@@ -1,0 +1,8 @@
+---
+"ember-intl": major
+"docs-app-for-ember-intl": minor
+"my-v2-addon": minor
+"test-app-for-ember-intl": minor
+---
+
+Updated the type of `primaryLocale` to be `string`

--- a/docs/ember-intl/src/docs/migration/v9.md
+++ b/docs/ember-intl/src/docs/migration/v9.md
@@ -121,7 +121,7 @@ module('Integration | Helper | format-message', function (hooks) {
       </template>,
     );
 
--     assert.dom().hasText('Hello, <span class="emphasize">Zoey</span>!');
+-     assert.dom().hasText('Hello, <span class="emphasize">Zoey</span>!'); // ❌ Incorrect
 +     assert.dom().hasText('Hello, Zoey!');
   });
 
@@ -137,7 +137,7 @@ module('Integration | Helper | format-message', function (hooks) {
     );
 
 -     assert.dom().hasText('Hello, Zoey!');
-+     assert.dom().hasText('Hello, ,Zoey,!');
++     assert.dom().hasText('Hello, ,Zoey,!'); // ❌ Incorrect
   });
 });
 ```
@@ -199,3 +199,74 @@ To clarify intent and remove references to implementation details in classic Emb
 | wrapTranslationsWithNamespace | namespaceKeysByDir |
 
 These packages will throw an error if you continue to use the old key name. Note, the key name `fallbackLocale` remains the same.
+
+
+### Strictened type for `primaryLocale` {#breaking-changes-strictened-type-for-primary-locale}
+
+From `5.x` to `8.x`, the getter `intl.primaryLocale` had the type of `string | undefined`. The type `undefined` shouldn't occur in practice, because `intl.setLocale()` is assumed to have been called first (in the `application` route).
+
+Going forward, `intl.primaryLocale` will have the stricter type of `string`. In development, `ember-intl` will throw an error if you access the getter without calling `setLocale()`.
+
+Run TypeScript (Glint) to see where to update code. The autofix from `typescript-eslint` can remove unnecessary type assertions (`!`'s).
+
+::: code-group
+
+```diff [Example]
+type FirstDayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+function getFirstDayOfWeek(locale: string): FirstDayOfWeek {
+  const intlLocale = new Intl.Locale(locale);
+  const { firstDay } = intlLocale.getWeekInfo();
+
+  return (firstDay % 7) as FirstDayOfWeek;
+}
+
+- getFirstDayOfWeek(this.intl.primaryLocale!);
++ getFirstDayOfWeek(this.intl.primaryLocale);
+```
+
+:::
+
+
+### Strictened type for `setLocale()` {#breaking-changes-strictened-type-for-set-locale}
+
+From `5.x` to `8.x`, the method `intl.setLocale` had the type of `string | string[]`. The type `string[]` allows an empty array, which shouldn't occur in practice.
+
+Going forward, `intl.setLocale()` will have the stricter type of `string | Locales`, where `Locales` is defined to be an array with at least 1 element:
+
+```ts
+type Locales = [string, ...string[]];
+```
+
+Run TypeScript (Glint) to see where to update code.
+
+::: code-group
+
+```diff [Example]
+type SupportedLocale = 'de-de' | 'en-us';
+
+export default class SelectLocale extends Component {
+  @service declare intl: Services['intl'];
+
+  updateLocale(value: SupportedLocale): void {
+-     let locale: string[];
++     let locale: [string, ...string[]];
+
+    switch (value) {
+      case 'de-de': {
+        locale = ['de-de', 'en-us'];
+        break;
+      }
+
+      case 'en-us': {
+        locale = ['en-us'];
+        break;
+      }
+    }
+
+    this.intl.setLocale(locale);
+  }
+}
+```
+
+:::

--- a/docs/my-v2-addon/src/components/select-locale.gts
+++ b/docs/my-v2-addon/src/components/select-locale.gts
@@ -46,7 +46,7 @@ export default class SelectLocale extends Component<SelectLocaleSignature> {
   }
 
   updateLocale(value: SupportedLocale): void {
-    let locale: string[];
+    let locale: [string, ...string[]];
 
     switch (value) {
       case 'de-de': {

--- a/packages/ember-intl/src/-private/utils/locale.ts
+++ b/packages/ember-intl/src/-private/utils/locale.ts
@@ -20,16 +20,14 @@ export function convertToString(locale: string | string[]): string {
   return locale;
 }
 
-type MaybeLocale = null | string | string[] | undefined;
-
 /**
  * @private
  */
 export function hasLocaleChanged(
   locale1: string[],
-  locale2: MaybeLocale,
+  locale2?: string[],
 ): boolean {
-  if (!Array.isArray(locale2)) {
+  if (locale2 === undefined) {
     return true;
   }
 

--- a/packages/ember-intl/src/-private/utils/locale.ts
+++ b/packages/ember-intl/src/-private/utils/locale.ts
@@ -1,7 +1,9 @@
+export type Locales = [string, ...string[]];
+
 /**
  * @private
  */
-export function convertToArray(locale: string | string[]): string[] {
+export function convertToArray(locale: Locales | string): Locales {
   if (Array.isArray(locale)) {
     return locale;
   }
@@ -12,9 +14,9 @@ export function convertToArray(locale: string | string[]): string[] {
 /**
  * @private
  */
-export function convertToString(locale: string | string[]): string {
+export function convertToString(locale: Locales | string): string {
   if (Array.isArray(locale)) {
-    return locale[0]!;
+    return locale[0];
   }
 
   return locale;
@@ -23,10 +25,7 @@ export function convertToString(locale: string | string[]): string {
 /**
  * @private
  */
-export function hasLocaleChanged(
-  locale1: string[],
-  locale2?: string[],
-): boolean {
+export function hasLocaleChanged(locale1: Locales, locale2?: Locales): boolean {
   if (locale2 === undefined) {
     return true;
   }

--- a/packages/ember-intl/src/services/intl.ts
+++ b/packages/ember-intl/src/services/intl.ts
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { cancel, next, type Timer as EmberRunTimer } from '@ember/runloop';
 import Service from '@ember/service';
 import { htmlSafe } from '@ember/template';
@@ -88,11 +89,10 @@ export default class IntlService extends Service {
   get primaryLocale(): string {
     const primaryLocale = this._locales?.[0];
 
-    if (!primaryLocale) {
-      throw new Error(
-        'ember-intl: locale is missing. Make sure to call `intl.setLocale(...)` first.',
-      );
-    }
+    assert(
+      'intl.primaryLocale is undefined. Did you call intl.setLocale()?',
+      primaryLocale,
+    );
 
     return primaryLocale;
   }

--- a/packages/ember-intl/src/services/intl.ts
+++ b/packages/ember-intl/src/services/intl.ts
@@ -50,7 +50,7 @@ type OnMissingTranslation = (
 
 export default class IntlService extends Service {
   @tracked private _intls: Record<string, IntlShape> = {};
-  @tracked private _locale?: string[];
+  @tracked private _locales?: string[];
 
   private _cache = createIntlCache();
   private _formats: Formats = {};
@@ -85,11 +85,11 @@ export default class IntlService extends Service {
   }
 
   get primaryLocale(): string | undefined {
-    if (!this._locale) {
+    if (!this._locales) {
       return;
     }
 
-    return this._locale[0];
+    return this._locales[0];
   }
 
   addTranslations(locale: string, translations: TranslationJson): void {
@@ -118,7 +118,7 @@ export default class IntlService extends Service {
   }
 
   exists(key: string, locale?: string | string[]): boolean {
-    const locales = locale ? convertToArray(locale) : this._locale!;
+    const locales = locale ? convertToArray(locale) : this._locales!;
 
     return locales.some((locale) => {
       return this.getTranslation(key, locale) !== undefined;
@@ -278,7 +278,7 @@ export default class IntlService extends Service {
       return this.createIntl(locale);
     }
 
-    return this.getIntl(this._locale!)!;
+    return this.getIntl(this._locales!)!;
   }
 
   getTranslation(key: string, locale: string): string | undefined {
@@ -303,8 +303,8 @@ export default class IntlService extends Service {
   setLocale(locale: string | string[]): void {
     const proposedLocale = convertToArray(locale);
 
-    if (hasLocaleChanged(proposedLocale, this._locale)) {
-      this._locale = proposedLocale;
+    if (hasLocaleChanged(proposedLocale, this._locales)) {
+      this._locales = proposedLocale;
 
       // eslint-disable-next-line ember/no-runloop
       cancel(this._timer);
@@ -338,7 +338,7 @@ export default class IntlService extends Service {
       locale?: string;
     },
   ): string {
-    const locales = options?.locale ? [options.locale] : this._locale!;
+    const locales = options?.locale ? [options.locale] : this._locales!;
     let translation: string | undefined;
 
     for (const locale of locales) {

--- a/packages/ember-intl/src/services/intl.ts
+++ b/packages/ember-intl/src/services/intl.ts
@@ -34,6 +34,7 @@ import {
   convertToArray,
   convertToString,
   hasLocaleChanged,
+  type Locales,
   normalizeLocale,
 } from '../-private/utils/locale.ts';
 import type { TranslationJson } from '../-private/utils/translations.ts';
@@ -44,13 +45,13 @@ type OnFormatjsError = (error: Parameters<OnErrorFn>[0]) => void;
 
 type OnMissingTranslation = (
   key: string,
-  locales: string[],
+  locales: Locales,
   data?: Record<string, unknown>,
 ) => string;
 
 export default class IntlService extends Service {
   @tracked private _intls: Record<string, IntlShape> = {};
-  @tracked private _locales?: string[];
+  @tracked private _locales?: Locales;
 
   private _cache = createIntlCache();
   private _formats: Formats = {};
@@ -97,7 +98,7 @@ export default class IntlService extends Service {
   }
 
   private createIntl(
-    locale: string | string[],
+    locale: Locales | string,
     messages: Record<string, unknown> = {},
   ): IntlShape {
     const resolvedLocale = convertToString(locale);
@@ -117,7 +118,7 @@ export default class IntlService extends Service {
     );
   }
 
-  exists(key: string, locale?: string | string[]): boolean {
+  exists(key: string, locale?: Locales | string): boolean {
     const locales = locale ? convertToArray(locale) : this._locales!;
 
     return locales.some((locale) => {
@@ -267,7 +268,7 @@ export default class IntlService extends Service {
     return formatTime(intlShape, value, options);
   }
 
-  private getIntl(locale: string | string[]): IntlShape | undefined {
+  private getIntl(locale: Locales | string): IntlShape | undefined {
     const resolvedLocale = normalizeLocale(convertToString(locale));
 
     return this._intls[resolvedLocale];
@@ -300,7 +301,7 @@ export default class IntlService extends Service {
     });
   }
 
-  setLocale(locale: string | string[]): void {
+  setLocale(locale: Locales | string): void {
     const proposedLocale = convertToArray(locale);
 
     if (hasLocaleChanged(proposedLocale, this._locales)) {
@@ -338,7 +339,10 @@ export default class IntlService extends Service {
       locale?: string;
     },
   ): string {
-    const locales = options?.locale ? [options.locale] : this._locales!;
+    const locales: Locales = options?.locale
+      ? [options.locale]
+      : this._locales!;
+
     let translation: string | undefined;
 
     for (const locale of locales) {
@@ -379,7 +383,7 @@ export default class IntlService extends Service {
   }
 
   private updateIntl(
-    locale: string | string[],
+    locale: Locales | string,
     messages?: Record<string, unknown>,
   ): void {
     const resolvedLocale = normalizeLocale(convertToString(locale));

--- a/packages/ember-intl/src/services/intl.ts
+++ b/packages/ember-intl/src/services/intl.ts
@@ -85,12 +85,16 @@ export default class IntlService extends Service {
     return Object.keys(this._intls);
   }
 
-  get primaryLocale(): string | undefined {
-    if (!this._locales) {
-      return;
+  get primaryLocale(): string {
+    const primaryLocale = this._locales?.[0];
+
+    if (!primaryLocale) {
+      throw new Error(
+        'ember-intl: locale is missing. Make sure to call `intl.setLocale(...)` first.',
+      );
     }
 
-    return this._locales[0];
+    return primaryLocale;
   }
 
   addTranslations(locale: string, translations: TranslationJson): void {
@@ -373,13 +377,12 @@ export default class IntlService extends Service {
 
   private updateDocumentLanguage(): void {
     const html = getHtmlElement(this);
-    const { primaryLocale } = this;
 
-    if (!html || !primaryLocale) {
+    if (!html) {
       return;
     }
 
-    html.setAttribute('lang', primaryLocale);
+    html.setAttribute('lang', this.primaryLocale);
   }
 
   private updateIntl(

--- a/tests/ember-intl/tests/unit/services/intl/getters-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl/getters-test.ts
@@ -1,6 +1,5 @@
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
-import { setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import { setupTest } from 'test-app-for-ember-intl/tests/helpers';
 
@@ -10,7 +9,6 @@ interface TestContext extends BaseTestContext {
 
 module('Unit | Service | intl > getters', function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function (this: TestContext) {
     this.intl = this.owner.lookup('service:intl');
@@ -21,6 +19,21 @@ module('Unit | Service | intl > getters', function (hooks) {
   });
 
   test('primaryLocale', function (this: TestContext, assert) {
+    this.intl.setLocale('en-us');
+
     assert.strictEqual(this.intl.primaryLocale, 'en-us');
+  });
+
+  test('primaryLocale returns first locale of fallback chain', function (this: TestContext, assert) {
+    this.intl.setLocale(['fr-ca', 'fr', 'en-us']);
+
+    assert.strictEqual(this.intl.primaryLocale, 'fr-ca');
+  });
+
+  test('primaryLocale throws when setLocale has not been called', function (this: TestContext, assert) {
+    assert.throws(
+      () => this.intl.primaryLocale,
+      /ember-intl: locale is missing\. Make sure to call `intl\.setLocale\(\.\.\.\)` first\./,
+    );
   });
 });

--- a/tests/ember-intl/tests/unit/services/intl/getters-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl/getters-test.ts
@@ -14,26 +14,41 @@ module('Unit | Service | intl > getters', function (hooks) {
     this.intl = this.owner.lookup('service:intl');
   });
 
-  test('locales', function (this: TestContext, assert) {
-    assert.deepEqual(this.intl.locales, ['de-de', 'en-us']);
+  module('locales', function () {
+    test('it works', function (this: TestContext, assert) {
+      assert.deepEqual(this.intl.locales, ['de-de', 'en-us']);
+    });
   });
 
-  test('primaryLocale', function (this: TestContext, assert) {
-    this.intl.setLocale('en-us');
+  module('primaryLocale', function () {
+    test('locale is a string', function (this: TestContext, assert) {
+      this.intl.setLocale('en-us');
 
-    assert.strictEqual(this.intl.primaryLocale, 'en-us');
-  });
+      assert.strictEqual(this.intl.primaryLocale, 'en-us');
+    });
 
-  test('primaryLocale returns first locale of fallback chain', function (this: TestContext, assert) {
-    this.intl.setLocale(['fr-ca', 'fr', 'en-us']);
+    test('locale is an array with 1 element', function (this: TestContext, assert) {
+      this.intl.setLocale(['en-us']);
 
-    assert.strictEqual(this.intl.primaryLocale, 'fr-ca');
-  });
+      assert.strictEqual(this.intl.primaryLocale, 'en-us');
+    });
 
-  test('primaryLocale throws when setLocale has not been called', function (this: TestContext, assert) {
-    assert.throws(
-      () => this.intl.primaryLocale,
-      /ember-intl: locale is missing\. Make sure to call `intl\.setLocale\(\.\.\.\)` first\./,
-    );
+    test('locale is an array with more than 1 element', function (this: TestContext, assert) {
+      this.intl.setLocale(['fr-ca', 'fr', 'en-us']);
+
+      assert.strictEqual(this.intl.primaryLocale, 'fr-ca');
+    });
+
+    test('throws an error if setLocale has not been called', function (this: TestContext, assert) {
+      assert.throws(
+        () => this.intl.primaryLocale,
+        (error: Error) => {
+          return (
+            error.message ===
+            'Assertion Failed: intl.primaryLocale is undefined. Did you call intl.setLocale()?'
+          );
+        },
+      );
+    });
   });
 });


### PR DESCRIPTION
## Why?

Supercedes #2146.

From `5.x` to `8.x`, the getter `intl.primaryLocale` had the type of `string | undefined`. The type `undefined` shouldn't occur in practice, because `intl.setLocale()` is assumed to have been called first (in the `application` route).

Similarly, from `5.x` to `8.x`, the method `intl.setLocale` had the type of `string | string[]`. The type `string[]` allows an empty array, which shouldn't occur in practice.


## Solution?

`primaryLocale`: After refactoring code, I cherry-picked the commits from #2146, then replaced `throw new Error()` with `assert()` from `@ember/debug`. This is so that the conditional check doesn't occur in production.

To reduce scope, I didn't check which of the remaining `string`'s in the `intl` service could be changed to the "singular" type `Locale`. The type `Locale` (defined to be `string`) would be defined in `packages/ember-intl/src/-private/utils/locale.ts`.
